### PR TITLE
Add Fn key debug combos and runtime debug mode

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -773,6 +773,7 @@ dependencies = [
  "esp-hal",
  "esp-println",
  "esp-rtos",
+ "esp32s3",
  "log",
  "static_cell",
  "tinygif",

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -16,6 +16,7 @@ log = { version = "0.4" }
 static_cell = { version = "1", features = ["nightly"] }
 embedded-graphics-core = "0.4.0"
 critical-section = "1"
+esp32s3 = "0.34.0"
 embedded-hal = "1"
 
 embassy-time = { version = "0.5" }

--- a/firmware/src/keyboard.rs
+++ b/firmware/src/keyboard.rs
@@ -16,7 +16,69 @@ use embassy_usb::{Builder, Handler};
 use usbd_hid::descriptor::KeyboardReport;
 use usbd_hid::descriptor::SerializedDescriptor;
 
-use crate::keymap::{DEBOUNCE_SCANS, KEYMAP, NUM_COLS, NUM_ROWS};
+use crate::keymap::{
+    DEBOUNCE_SCANS, FN_COL, FN_ROW, KEY_BACKSPACE, KEY_D, KEY_ESC, KEYMAP, NUM_COLS, NUM_ROWS,
+};
+
+const DEBUG_MODE_MAGIC: u32 = 0xDBE6_F1A6;
+
+fn rtc_cntl() -> &'static esp32s3::rtc_cntl::RegisterBlock {
+    unsafe { &*esp32s3::RTC_CNTL::PTR }
+}
+
+/// Check if debug mode was requested (persisted in RTC store register across resets).
+pub fn is_debug_mode() -> bool {
+    rtc_cntl().store6().read().bits() == DEBUG_MODE_MAGIC
+}
+
+fn toggle_debug_mode() -> ! {
+    let current = rtc_cntl().store6().read().bits();
+    let new = if current == DEBUG_MODE_MAGIC { 0 } else { DEBUG_MODE_MAGIC };
+    rtc_cntl().store6().write(|w| unsafe { w.bits(new) });
+    if new == DEBUG_MODE_MAGIC {
+        info!("Switching to debug mode...");
+    } else {
+        info!("Switching to normal mode...");
+    }
+    esp_hal::system::software_reset();
+}
+
+fn reset_to_download_mode() -> ! {
+    info!("Resetting to download mode...");
+    rtc_cntl()
+        .option1()
+        .modify(|_, w| w.force_download_boot().set_bit());
+    esp_hal::system::software_reset();
+}
+
+/// Check pressed keys for Fn combos. Returns true if Fn is held (suppresses HID report).
+fn handle_fn_combos(key_state: &[[bool; NUM_COLS]; NUM_ROWS]) -> bool {
+    if !key_state[FN_ROW][FN_COL] {
+        return false;
+    }
+
+    // Scan for combo keys by checking keycodes in the keymap
+    for y in 0..NUM_ROWS {
+        for x in 0..NUM_COLS {
+            if (y, x) == (FN_ROW, FN_COL) {
+                continue;
+            }
+            if !key_state[y][x] {
+                continue;
+            }
+            let (_mod_bits, keycode) = KEYMAP[y][x];
+            match keycode {
+                KEY_ESC => esp_hal::system::software_reset(),
+                KEY_BACKSPACE => reset_to_download_mode(),
+                KEY_D => toggle_debug_mode(),
+                _ => {}
+            }
+        }
+    }
+
+    // Fn held but no recognized combo — still suppress HID output
+    true
+}
 
 #[embassy_executor::task]
 pub async fn usb(
@@ -134,6 +196,12 @@ pub async fn matrix(
         }
 
         if state_changed {
+            // Check Fn combos first — resets never return, other combos suppress HID
+            if handle_fn_combos(&key_state) {
+                Timer::after(Duration::from_millis(1)).await;
+                continue;
+            }
+
             let mut modifier = 0u8;
             let mut keycodes = [0u8; 6];
             let mut keycode_idx = 0usize;
@@ -198,7 +266,6 @@ impl MyDeviceHandler {
     }
 }
 
-#[cfg(feature = "debug-matrix")]
 #[embassy_executor::task]
 pub async fn debug_consumer(
     signal: &'static Signal<CriticalSectionRawMutex, KeyboardReport>,

--- a/firmware/src/keymap.rs
+++ b/firmware/src/keymap.rs
@@ -29,3 +29,12 @@ pub const KEYMAP: [[KeyDef; NUM_COLS]; NUM_ROWS] = [
 pub const NUM_ROWS: usize = 5;
 pub const NUM_COLS: usize = 14;
 pub const DEBOUNCE_SCANS: u8 = 5;
+
+/// Fn key position in the matrix (row 4, col 8)
+pub const FN_ROW: usize = 4;
+pub const FN_COL: usize = 8;
+
+// HID keycodes used for Fn combo detection
+pub const KEY_ESC: u8 = 0x29;
+pub const KEY_BACKSPACE: u8 = 0x2A;
+pub const KEY_D: u8 = 0x07;

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -21,7 +21,6 @@ use esp_hal::gpio::Level;
 use esp_hal::interrupt;
 use esp_hal::interrupt::software::SoftwareInterruptControl;
 use esp_hal::interrupt::Priority;
-#[cfg(not(feature = "debug-matrix"))]
 use esp_hal::otg_fs::Usb;
 use esp_hal::peripherals::Interrupt;
 use esp_hal::system::Stack;
@@ -183,17 +182,23 @@ fn main() -> ! {
         sw_ints.software_interrupt1,
         unsafe { &mut *addr_of_mut!(APP_CORE_STACK) },
         || {
-            #[cfg(not(feature = "debug-matrix"))]
-            let device = Usb::new(peripherals.USB0, peripherals.GPIO20, peripherals.GPIO19);
+            let debug = cfg!(feature = "debug-matrix") || keyboard::is_debug_mode();
             let signal = &*make_static!(Signal<CriticalSectionRawMutex, KeyboardReport>, Signal::new());
             let executor = make_static!(Executor, Executor::new());
-            executor.run(|spawner| {
-                spawner.must_spawn(keyboard::matrix(columns, rows, signal));
-                #[cfg(not(feature = "debug-matrix"))]
-                spawner.must_spawn(keyboard::usb(device, signal));
-                #[cfg(feature = "debug-matrix")]
-                spawner.must_spawn(keyboard::debug_consumer(signal));
-            });
+
+            if debug {
+                log::info!("Booting in debug mode (Fn+D to switch back)");
+                executor.run(|spawner| {
+                    spawner.must_spawn(keyboard::matrix(columns, rows, signal));
+                    spawner.must_spawn(keyboard::debug_consumer(signal));
+                });
+            } else {
+                let device = Usb::new(peripherals.USB0, peripherals.GPIO20, peripherals.GPIO19);
+                executor.run(|spawner| {
+                    spawner.must_spawn(keyboard::matrix(columns, rows, signal));
+                    spawner.must_spawn(keyboard::usb(device, signal));
+                });
+            }
         },
     );
 


### PR DESCRIPTION
## Summary
- Fn key (bottom-right, row 4 col 8) acts as firmware-level modifier for debug shortcuts
- **Fn + Esc** — software reset
- **Fn + Backspace** — reset to USB download mode (sets `RTC_CNTL_OPTION1_REG` force-download-boot flag)
- **Fn + D** — toggle between normal USB HID mode and debug mode (JTAG serial logging)
- Debug mode flag persisted in RTC store register across soft resets, no reflash needed to switch
- When Fn is held, all HID output is suppressed (invisible to host)
- `debug-matrix` cargo feature still works as compile-time override

## Test plan
- [ ] Fn + Esc resets the board (display restarts)
- [ ] Fn + Backspace enters USB download mode (DFU device appears on host)
- [ ] Fn + D switches to debug mode (JTAG serial shows key press/release logs)
- [ ] Fn + D again switches back to normal USB HID mode
- [ ] Normal typing works when Fn is not held
- [ ] Holding Fn alone produces no USB output