### PR TITLE
Add USB CDC logging, custom panic handler, drop esp-println

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -479,23 +479,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "esp-backtrace"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3318413fb566c7227387f67736cf70cd74d80a11f2bb31c7b95a9eb48d079669"
-dependencies = [
- "cfg-if",
- "document-features",
- "esp-config",
- "esp-metadata-generated",
- "esp-println",
- "heapless 0.9.1",
- "riscv",
- "semihosting",
- "xtensa-lx",
-]
-
-[[package]]
 name = "esp-bootloader-esp-idf"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,19 +584,6 @@ name = "esp-metadata-generated"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a93e39c8ad8d390d248dc7b9f4b59a873f313bf535218b8e2351356972399e3"
-
-[[package]]
-name = "esp-println"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a30e6c9fbcc01c348d46706fef8131c7775ab84c254a3cd65d0cd3f6414d592"
-dependencies = [
- "document-features",
- "esp-metadata-generated",
- "esp-sync",
- "log",
- "portable-atomic",
-]
 
 [[package]]
 name = "esp-riscv-rt"
@@ -768,10 +738,8 @@ dependencies = [
  "embedded-graphics",
  "embedded-graphics-core",
  "embedded-hal 1.0.0",
- "esp-backtrace",
  "esp-bootloader-esp-idf",
  "esp-hal",
- "esp-println",
  "esp-rtos",
  "esp32s3",
  "log",
@@ -901,16 +869,6 @@ name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32 0.3.1",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
 dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",
@@ -1220,12 +1178,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semihosting"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e1c7d2b77d80283c750a39c52f1ab4d17234e8f30bca43550f5b2375f41d5f"
 
 [[package]]
 name = "semver"

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -8,8 +8,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 esp-hal = { version = "1.0.0", features = ["esp32s3", "log-04", "unstable"] }
 esp-rtos  = { version = "0.2",  features = ["esp32s3", "embassy"] }
-esp-backtrace = { version = "0.18", features = ["esp32s3", "println"] }
-esp-println = { version = "0.16", default-features = false, features = ["esp32s3", "log-04", "jtag-serial"] }
 esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp32s3"] }
 
 log = { version = "0.4" }

--- a/firmware/src/keyboard.rs
+++ b/firmware/src/keyboard.rs
@@ -10,6 +10,7 @@ use esp_hal::gpio::{Input, Output};
 use esp_hal::otg_fs;
 use esp_hal::otg_fs::asynch::{Config, Driver};
 
+use embassy_usb::class::cdc_acm::CdcAcmClass;
 use embassy_usb::class::hid::{HidReaderWriter, ReportId, RequestHandler, State};
 use embassy_usb::control::OutResponse;
 use embassy_usb::{Builder, Handler};
@@ -86,14 +87,15 @@ pub async fn usb(
     let mut ep_out_buffer = [0u8; 1024];
     let driver = Driver::new(usb, &mut ep_out_buffer, Config::default());
 
-    let mut config_descriptor = [0; 256];
+    let mut config_descriptor = [0; 384];
     let mut bos_descriptor = [0; 256];
     let mut msos_descriptor = [0; 256];
     let mut control_buf = [0; 64];
     let mut request_handler = MyRequestHandler {};
     let mut device_handler = MyDeviceHandler::new();
 
-    let mut state = State::new();
+    let mut hid_state = State::new();
+    let mut cdc_state = embassy_usb::class::cdc_acm::State::new();
 
     let mut config = embassy_usb::Config::new(0x16c0, 0x27dd);
     config.max_power = 100;
@@ -113,19 +115,24 @@ pub async fn usb(
 
     builder.handler(&mut device_handler);
 
-    let config = embassy_usb::class::hid::Config {
+    // HID keyboard class
+    let hid_config = embassy_usb::class::hid::Config {
         report_descriptor: KeyboardReport::desc(),
         request_handler: None,
         poll_ms: 60,
         max_packet_size: 64,
     };
-    let hid = HidReaderWriter::<_, 1, 8>::new(&mut builder, &mut state, config);
+    let hid = HidReaderWriter::<_, 1, 8>::new(&mut builder, &mut hid_state, hid_config);
+
+    // CDC ACM serial class (for log output)
+    let cdc = CdcAcmClass::new(&mut builder, &mut cdc_state, 64);
+    let (mut cdc_sender, _cdc_receiver) = cdc.split();
 
     let mut usb = builder.build();
 
     let (reader, mut writer) = hid.split();
 
-    let in_fut = async {
+    let hid_in_fut = async {
         loop {
             let report = signal.wait().await;
             match writer.write_serialize(&report).await {
@@ -135,13 +142,30 @@ pub async fn usb(
         }
     };
 
-    let out_fut = async {
+    let hid_out_fut = async {
         reader.run(false, &mut request_handler).await;
     };
 
-    // Run everything concurrently.
-    // If we had made everything `'static` above instead, we could do this using separate tasks instead.
-    join(usb.run(), join(in_fut, out_fut)).await;
+    let cdc_fut = async {
+        // Send saved panic message if there was one
+        if let Some(msg) = crate::panic::take_panic_message() {
+            let _ = cdc_sender.write_packet(b"\r\n========== PREVIOUS PANIC ==========\r\n").await;
+            for chunk in msg.as_bytes().chunks(64) {
+                let _ = cdc_sender.write_packet(chunk).await;
+            }
+            let _ = cdc_sender.write_packet(b"\r\n====================================\r\n").await;
+        }
+
+        // Drain log pipe forever
+        let mut buf = [0u8; 64];
+        loop {
+            let n = crate::log::LOG_PIPE.read(&mut buf).await;
+            let _ = cdc_sender.write_packet(&buf[..n]).await;
+        }
+    };
+
+    // Run everything concurrently
+    join(usb.run(), join(hid_in_fut, join(hid_out_fut, cdc_fut))).await;
 }
 
 #[embassy_executor::task]

--- a/firmware/src/keyboard.rs
+++ b/firmware/src/keyboard.rs
@@ -282,18 +282,13 @@ impl MyDeviceHandler {
     }
 }
 
+/// Debug mode: drain the log pipe to USB-SERIAL-JTAG.
 #[embassy_executor::task]
-pub async fn debug_consumer(
-    signal: &'static Signal<CriticalSectionRawMutex, KeyboardReport>,
-) -> ! {
+pub async fn jtag_drain(mut tx: esp_hal::usb_serial_jtag::UsbSerialJtagTx<'static, esp_hal::Blocking>) -> ! {
+    let mut buf = [0u8; 64];
     loop {
-        let report = signal.wait().await;
-        info!(
-            "HID Report: modifier={:#04x} keycodes=[{:#04x}, {:#04x}, {:#04x}, {:#04x}, {:#04x}, {:#04x}]",
-            report.modifier,
-            report.keycodes[0], report.keycodes[1], report.keycodes[2],
-            report.keycodes[3], report.keycodes[4], report.keycodes[5],
-        );
+        let n = crate::log::LOG_PIPE.read(&mut buf).await;
+        let _ = tx.write(&buf[..n]);
     }
 }
 

--- a/firmware/src/keyboard.rs
+++ b/firmware/src/keyboard.rs
@@ -159,7 +159,7 @@ pub async fn usb(
         // Drain log pipe forever
         let mut buf = [0u8; 64];
         loop {
-            let n = crate::log::LOG_PIPE.read(&mut buf).await;
+            let n = crate::logger::LOG_PIPE.read(&mut buf).await;
             let _ = cdc_sender.write_packet(&buf[..n]).await;
         }
     };
@@ -287,7 +287,7 @@ impl MyDeviceHandler {
 pub async fn jtag_drain(mut tx: esp_hal::usb_serial_jtag::UsbSerialJtagTx<'static, esp_hal::Blocking>) -> ! {
     let mut buf = [0u8; 64];
     loop {
-        let n = crate::log::LOG_PIPE.read(&mut buf).await;
+        let n = crate::logger::LOG_PIPE.read(&mut buf).await;
         let _ = tx.write(&buf[..n]);
     }
 }

--- a/firmware/src/log.rs
+++ b/firmware/src/log.rs
@@ -3,6 +3,8 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::pipe::Pipe;
+use esp_hal::usb_serial_jtag::UsbSerialJtagTx;
+use esp_hal::Blocking;
 
 /// Pipe for CDC log output. The logger pushes formatted bytes here (non-blocking),
 /// and the CDC writer task drains it over USB.
@@ -11,25 +13,39 @@ pub static LOG_PIPE: Pipe<CriticalSectionRawMutex, 512> = Pipe::new();
 static DEBUG_MODE: AtomicBool = AtomicBool::new(false);
 static LOGGER: MkeyLogger = MkeyLogger;
 
+static mut JTAG_TX: Option<UsbSerialJtagTx<'static, Blocking>> = None;
+
 /// Initialize the logging backend.
-/// - `debug = true`: logs go to USB-SERIAL-JTAG FIFO (no USB OTG)
+/// - `debug = true`: logs go to USB-SERIAL-JTAG (no USB OTG)
 /// - `debug = false`: logs go to CDC pipe (drained by USB task)
-pub fn init(debug: bool) {
+///
+/// The JTAG TX is always used for early boot output (before USB OTG takes over).
+pub fn init(debug: bool, jtag_tx: UsbSerialJtagTx<'static, Blocking>) {
     DEBUG_MODE.store(debug, Ordering::Relaxed);
+    unsafe { (*core::ptr::addr_of_mut!(JTAG_TX)) = Some(jtag_tx) };
     unsafe {
-        log::set_logger_racy(&LOGGER).ok();
-        log::set_max_level_racy(log::LevelFilter::Info);
+        ::log::set_logger_racy(&LOGGER).ok();
+        ::log::set_max_level_racy(::log::LevelFilter::Info);
     }
+}
+
+/// Write directly to USB-SERIAL-JTAG. Used by panic handler for early output.
+pub fn jtag_serial_write(data: &[u8]) {
+    critical_section::with(|_| unsafe {
+        if let Some(tx) = (*core::ptr::addr_of_mut!(JTAG_TX)).as_mut() {
+            let _ = tx.write(data);
+        }
+    });
 }
 
 struct MkeyLogger;
 
-impl log::Log for MkeyLogger {
-    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+impl ::log::Log for MkeyLogger {
+    fn enabled(&self, _metadata: &::log::Metadata) -> bool {
         true
     }
 
-    fn log(&self, record: &log::Record) {
+    fn log(&self, record: &::log::Record) {
         let mut buf = [0u8; 128];
         let mut w = BufWriter::new(&mut buf);
         let _ = write!(w, "[{}] {}\r\n", record.level(), record.args());
@@ -44,38 +60,6 @@ impl log::Log for MkeyLogger {
 
     fn flush(&self) {}
 }
-
-// ---------------------------------------------------------------------------
-// USB-SERIAL-JTAG FIFO writer (used in debug mode)
-// ---------------------------------------------------------------------------
-
-fn usb_device() -> &'static esp32s3::usb_device::RegisterBlock {
-    unsafe { &*esp32s3::USB_DEVICE::PTR }
-}
-
-/// Write bytes to the USB-SERIAL-JTAG TX FIFO.
-/// Blocks until all bytes are written. Max 64 bytes per flush.
-pub fn jtag_serial_write(data: &[u8]) {
-    let dev = usb_device();
-
-    for chunk in data.chunks(64) {
-        // Wait for FIFO space
-        while !dev.ep1_conf().read().serial_in_ep_data_free().bit() {}
-
-        for &byte in chunk {
-            dev.ep1()
-                .write(|w| unsafe { w.rdwr_byte().bits(byte) });
-        }
-
-        // Signal write complete
-        dev.ep1_conf().write(|w| w.wr_done().set_bit());
-    }
-}
-
-// ---------------------------------------------------------------------------
-// CDC writer — drains LOG_PIPE to a USB CDC ACM sender
-// ---------------------------------------------------------------------------
-
 
 // ---------------------------------------------------------------------------
 // Stack-based fmt::Write adapter (no alloc)

--- a/firmware/src/log.rs
+++ b/firmware/src/log.rs
@@ -1,46 +1,21 @@
 use core::fmt::Write;
-use core::sync::atomic::{AtomicBool, Ordering};
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::pipe::Pipe;
-use esp_hal::usb_serial_jtag::UsbSerialJtagTx;
-use esp_hal::Blocking;
 
-/// Pipe for CDC log output. The logger pushes formatted bytes here (non-blocking),
-/// and the CDC writer task drains it over USB.
+/// Log output pipe. The `log` facade pushes formatted bytes here (non-blocking).
+/// A consumer task drains it — CDC writer in normal mode, JTAG writer in debug mode.
+/// If no consumer is active or it falls behind, `try_write` silently drops data.
 pub static LOG_PIPE: Pipe<CriticalSectionRawMutex, 512> = Pipe::new();
 
-static DEBUG_MODE: AtomicBool = AtomicBool::new(false);
 static LOGGER: MkeyLogger = MkeyLogger;
 
-static mut JTAG_TX: Option<UsbSerialJtagTx<'static, Blocking>> = None;
-
-/// Initialize the logging backend.
-/// - `debug = true`: logs go to USB-SERIAL-JTAG (no USB OTG)
-/// - `debug = false`: logs go to CDC pipe (drained by USB task)
-///
-/// The JTAG TX is always used for early boot output (before USB OTG takes over).
-pub fn init(debug: bool, jtag_tx: UsbSerialJtagTx<'static, Blocking>) {
-    DEBUG_MODE.store(debug, Ordering::Relaxed);
-    unsafe { (*core::ptr::addr_of_mut!(JTAG_TX)) = Some(jtag_tx) };
+/// Set the global logger. No HAL types, no mode — just hooks up the `log` facade to the pipe.
+pub fn init() {
     unsafe {
         ::log::set_logger_racy(&LOGGER).ok();
         ::log::set_max_level_racy(::log::LevelFilter::Info);
     }
-}
-
-/// Write to USB-SERIAL-JTAG (best-effort, non-blocking).
-/// Drops bytes if the FIFO is full rather than blocking.
-pub fn jtag_serial_write(data: &[u8]) {
-    critical_section::with(|_| unsafe {
-        if let Some(tx) = (*core::ptr::addr_of_mut!(JTAG_TX)).as_mut() {
-            for &byte in data {
-                // write_byte_nb returns WouldBlock if FIFO full — just skip
-                let _ = tx.write_byte_nb(byte);
-            }
-            let _ = tx.flush_tx_nb();
-        }
-    });
 }
 
 struct MkeyLogger;
@@ -54,21 +29,11 @@ impl ::log::Log for MkeyLogger {
         let mut buf = [0u8; 128];
         let mut w = BufWriter::new(&mut buf);
         let _ = write!(w, "[{}] {}\r\n", record.level(), record.args());
-        let bytes = w.as_bytes();
-
-        if DEBUG_MODE.load(Ordering::Relaxed) {
-            jtag_serial_write(bytes);
-        } else {
-            let _ = LOG_PIPE.try_write(bytes);
-        }
+        let _ = LOG_PIPE.try_write(w.as_bytes());
     }
 
     fn flush(&self) {}
 }
-
-// ---------------------------------------------------------------------------
-// Stack-based fmt::Write adapter (no alloc)
-// ---------------------------------------------------------------------------
 
 struct BufWriter<'a> {
     buf: &'a mut [u8],

--- a/firmware/src/log.rs
+++ b/firmware/src/log.rs
@@ -29,11 +29,16 @@ pub fn init(debug: bool, jtag_tx: UsbSerialJtagTx<'static, Blocking>) {
     }
 }
 
-/// Write directly to USB-SERIAL-JTAG. Used by panic handler for early output.
+/// Write to USB-SERIAL-JTAG (best-effort, non-blocking).
+/// Drops bytes if the FIFO is full rather than blocking.
 pub fn jtag_serial_write(data: &[u8]) {
     critical_section::with(|_| unsafe {
         if let Some(tx) = (*core::ptr::addr_of_mut!(JTAG_TX)).as_mut() {
-            let _ = tx.write(data);
+            for &byte in data {
+                // write_byte_nb returns WouldBlock if FIFO full — just skip
+                let _ = tx.write_byte_nb(byte);
+            }
+            let _ = tx.flush_tx_nb();
         }
     });
 }

--- a/firmware/src/log.rs
+++ b/firmware/src/log.rs
@@ -1,0 +1,107 @@
+use core::fmt::Write;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::pipe::Pipe;
+
+/// Pipe for CDC log output. The logger pushes formatted bytes here (non-blocking),
+/// and the CDC writer task drains it over USB.
+pub static LOG_PIPE: Pipe<CriticalSectionRawMutex, 512> = Pipe::new();
+
+static DEBUG_MODE: AtomicBool = AtomicBool::new(false);
+static LOGGER: MkeyLogger = MkeyLogger;
+
+/// Initialize the logging backend.
+/// - `debug = true`: logs go to USB-SERIAL-JTAG FIFO (no USB OTG)
+/// - `debug = false`: logs go to CDC pipe (drained by USB task)
+pub fn init(debug: bool) {
+    DEBUG_MODE.store(debug, Ordering::Relaxed);
+    unsafe {
+        log::set_logger_racy(&LOGGER).ok();
+        log::set_max_level_racy(log::LevelFilter::Info);
+    }
+}
+
+struct MkeyLogger;
+
+impl log::Log for MkeyLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        let mut buf = [0u8; 128];
+        let mut w = BufWriter::new(&mut buf);
+        let _ = write!(w, "[{}] {}\r\n", record.level(), record.args());
+        let bytes = w.as_bytes();
+
+        if DEBUG_MODE.load(Ordering::Relaxed) {
+            jtag_serial_write(bytes);
+        } else {
+            let _ = LOG_PIPE.try_write(bytes);
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+// ---------------------------------------------------------------------------
+// USB-SERIAL-JTAG FIFO writer (used in debug mode)
+// ---------------------------------------------------------------------------
+
+fn usb_device() -> &'static esp32s3::usb_device::RegisterBlock {
+    unsafe { &*esp32s3::USB_DEVICE::PTR }
+}
+
+/// Write bytes to the USB-SERIAL-JTAG TX FIFO.
+/// Blocks until all bytes are written. Max 64 bytes per flush.
+pub fn jtag_serial_write(data: &[u8]) {
+    let dev = usb_device();
+
+    for chunk in data.chunks(64) {
+        // Wait for FIFO space
+        while !dev.ep1_conf().read().serial_in_ep_data_free().bit() {}
+
+        for &byte in chunk {
+            dev.ep1()
+                .write(|w| unsafe { w.rdwr_byte().bits(byte) });
+        }
+
+        // Signal write complete
+        dev.ep1_conf().write(|w| w.wr_done().set_bit());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CDC writer — drains LOG_PIPE to a USB CDC ACM sender
+// ---------------------------------------------------------------------------
+
+
+// ---------------------------------------------------------------------------
+// Stack-based fmt::Write adapter (no alloc)
+// ---------------------------------------------------------------------------
+
+struct BufWriter<'a> {
+    buf: &'a mut [u8],
+    pos: usize,
+}
+
+impl<'a> BufWriter<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+    fn as_bytes(&self) -> &[u8] {
+        &self.buf[..self.pos]
+    }
+}
+
+impl Write for BufWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let bytes = s.as_bytes();
+        let space = self.buf.len() - self.pos;
+        let n = bytes.len().min(space);
+        self.buf[self.pos..self.pos + n].copy_from_slice(&bytes[..n]);
+        self.pos += n;
+        Ok(())
+    }
+}

--- a/firmware/src/logger.rs
+++ b/firmware/src/logger.rs
@@ -13,19 +13,19 @@ static LOGGER: MkeyLogger = MkeyLogger;
 /// Set the global logger. No HAL types, no mode — just hooks up the `log` facade to the pipe.
 pub fn init() {
     unsafe {
-        ::log::set_logger_racy(&LOGGER).ok();
-        ::log::set_max_level_racy(::log::LevelFilter::Info);
+        log::set_logger_racy(&LOGGER).ok();
+        log::set_max_level_racy(log::LevelFilter::Info);
     }
 }
 
 struct MkeyLogger;
 
-impl ::log::Log for MkeyLogger {
-    fn enabled(&self, _metadata: &::log::Metadata) -> bool {
+impl log::Log for MkeyLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
         true
     }
 
-    fn log(&self, record: &::log::Record) {
+    fn log(&self, record: &log::Record) {
         let mut buf = [0u8; 128];
         let mut w = BufWriter::new(&mut buf);
         let _ = write!(w, "[{}] {}\r\n", record.level(), record.args());

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -71,35 +71,23 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
 
     let debug = cfg!(feature = "debug-matrix") || keyboard::is_debug_mode();
-    log::init(debug);
+    let usb_serial = esp_hal::usb_serial_jtag::UsbSerialJtag::new(peripherals.USB_DEVICE);
+    let (_rx, tx) = usb_serial.split();
+    log::init(debug, tx);
+
+    let delay = Delay::new();
 
     // Dump any panic message from a previous boot (over JTAG serial before USB takes over)
     if panic::check_previous_panic() {
         ::log::warn!("Previous panic detected — details above and via USB CDC");
+        delay.delay_millis(10_000);
     }
 
-    // V1.0 of the mKey has the USB DM and DP swapped.. oops. There is an EFUSE to swap the pins, yay! However,
-    // it is bugged, and doesn't swap the pullups too. We can work around this by correcting the pullups early in the program,
-    // as they are only used for signally to the host that we are a full speed device.
-    // If flash is fully erased without programming again, the USB-SERIAL-JTAG will cease to work, firmware
-    // will have to be flashed via UART0, at which point you can switch back.
-    #[cfg(feature = "usb-pin-exchange")]
-    {
-        let usj = unsafe { &*esp_hal::peripherals::USB_DEVICE::PTR };
-        usj.conf0().modify(|_, w| {
-            w.pad_pull_override()
-                .set_bit()
-                .dm_pullup()
-                .clear_bit()
-                .dp_pullup()
-                .set_bit()
-        });
-    }
+    // Note: the USB_EXCHG_PINS efuse pullup workaround is handled automatically
+    // by UsbSerialJtag::new() above (checks efuse and fixes pullups if needed).
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0);
-
-    let delay = Delay::new();
 
     let mut io = Io::new(peripherals.IO_MUX);
     io.set_interrupt_handler(display::te);

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -71,19 +71,21 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
 
     let debug = cfg!(feature = "debug-matrix") || keyboard::is_debug_mode();
-    let usb_serial = esp_hal::usb_serial_jtag::UsbSerialJtag::new(peripherals.USB_DEVICE);
-    let (_rx, tx) = usb_serial.split();
-    log::init(debug, tx);
 
-    let delay = Delay::new();
-
-    // Check for panic from previous boot — message will be sent over USB CDC once enumerated
+    // Early JTAG serial for panic dump (direct write, before logger or USB OTG)
+    let mut usb_serial = esp_hal::usb_serial_jtag::UsbSerialJtag::new(peripherals.USB_DEVICE);
     if panic::check_previous_panic() {
-        warn!("Previous panic detected — will send details over USB CDC");
+        if let Some(msg) = panic::take_panic_message() {
+            let _ = usb_serial.write(b"\r\n=== PREVIOUS PANIC ===\r\n");
+            let _ = usb_serial.write(msg.as_bytes());
+            let _ = usb_serial.write(b"\r\n======================\r\n");
+        }
     }
 
-    // Note: the USB_EXCHG_PINS efuse pullup workaround is handled automatically
-    // by UsbSerialJtag::new() above (checks efuse and fixes pullups if needed).
+    // Logger just pushes to a pipe — consumer (CDC or JTAG) is set up later on core 1
+    log::init();
+
+    let delay = Delay::new();
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0);
@@ -182,12 +184,13 @@ fn main() -> ! {
             let executor = make_static!(Executor, Executor::new());
 
             if debug {
-                info!("Booting in debug mode (Fn+D to switch back)");
+                let (_rx, tx) = usb_serial.split();
                 executor.run(|spawner| {
                     spawner.must_spawn(keyboard::matrix(columns, rows, signal));
-                    spawner.must_spawn(keyboard::debug_consumer(signal));
+                    spawner.must_spawn(keyboard::jtag_drain(tx));
                 });
             } else {
+                drop(usb_serial);
                 let device = Usb::new(peripherals.USB0, peripherals.GPIO20, peripherals.GPIO19);
                 executor.run(|spawner| {
                     spawner.must_spawn(keyboard::matrix(columns, rows, signal));

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -77,10 +77,9 @@ fn main() -> ! {
 
     let delay = Delay::new();
 
-    // Dump any panic message from a previous boot (over JTAG serial before USB takes over)
+    // Check for panic from previous boot — message will be sent over USB CDC once enumerated
     if panic::check_previous_panic() {
-        ::log::warn!("Previous panic detected — details above and via USB CDC");
-        delay.delay_millis(10_000);
+        ::log::warn!("Previous panic detected — will send details over USB CDC");
     }
 
     // Note: the USB_EXCHG_PINS efuse pullup workaround is handled automatically

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -61,7 +61,7 @@ pub mod fmt;
 mod display;
 mod keyboard;
 mod keymap;
-mod log;
+mod logger;
 mod panic;
 
 static mut APP_CORE_STACK: Stack<8192> = Stack::new();
@@ -76,7 +76,7 @@ fn main() -> ! {
     panic::check_previous_panic();
 
     // Logger just pushes to a pipe — consumer (CDC or JTAG) is set up later on core 1
-    log::init();
+    logger::init();
 
     let delay = Delay::new();
 

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -72,15 +72,8 @@ fn main() -> ! {
 
     let debug = cfg!(feature = "debug-matrix") || keyboard::is_debug_mode();
 
-    // Early JTAG serial for panic dump (direct write, before logger or USB OTG)
-    let mut usb_serial = esp_hal::usb_serial_jtag::UsbSerialJtag::new(peripherals.USB_DEVICE);
-    if panic::check_previous_panic() {
-        if let Some(msg) = panic::take_panic_message() {
-            let _ = usb_serial.write(b"\r\n=== PREVIOUS PANIC ===\r\n");
-            let _ = usb_serial.write(msg.as_bytes());
-            let _ = usb_serial.write(b"\r\n======================\r\n");
-        }
-    }
+    // Check for panic from previous boot — message will be sent over CDC once USB enumerates
+    panic::check_previous_panic();
 
     // Logger just pushes to a pipe — consumer (CDC or JTAG) is set up later on core 1
     log::init();
@@ -184,13 +177,13 @@ fn main() -> ! {
             let executor = make_static!(Executor, Executor::new());
 
             if debug {
+                let usb_serial = esp_hal::usb_serial_jtag::UsbSerialJtag::new(peripherals.USB_DEVICE);
                 let (_rx, tx) = usb_serial.split();
                 executor.run(|spawner| {
                     spawner.must_spawn(keyboard::matrix(columns, rows, signal));
                     spawner.must_spawn(keyboard::jtag_drain(tx));
                 });
             } else {
-                drop(usb_serial);
                 let device = Usb::new(peripherals.USB0, peripherals.GPIO20, peripherals.GPIO19);
                 executor.run(|spawner| {
                     spawner.must_spawn(keyboard::matrix(columns, rows, signal));

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -61,6 +61,7 @@ pub mod fmt;
 mod display;
 mod keyboard;
 mod keymap;
+mod log;
 mod panic;
 
 static mut APP_CORE_STACK: Stack<8192> = Stack::new();
@@ -69,10 +70,13 @@ static mut APP_CORE_STACK: Stack<8192> = Stack::new();
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
 
-    esp_println::logger::init_logger_from_env();
+    let debug = cfg!(feature = "debug-matrix") || keyboard::is_debug_mode();
+    log::init(debug);
 
-    // Dump any panic message from a previous boot (before USB takes over JTAG serial)
-    panic::check_previous_panic();
+    // Dump any panic message from a previous boot (over JTAG serial before USB takes over)
+    if panic::check_previous_panic() {
+        ::log::warn!("Previous panic detected — details above and via USB CDC");
+    }
 
     // V1.0 of the mKey has the USB DM and DP swapped.. oops. There is an EFUSE to swap the pins, yay! However,
     // it is bugged, and doesn't swap the pullups too. We can work around this by correcting the pullups early in the program,
@@ -144,7 +148,7 @@ fn main() -> ! {
     for (cmd, data) in WEA2012_INIT_CMDS {
         lcd_write_cmd(&mut spi, *cmd, data);
     }
-    log::info!("Finished initializing display!");
+    ::log::info!("Finished initializing display!");
 
     let pixels = unsafe { &mut *addr_of_mut!(FRAME_BUFFER) };
     /*
@@ -186,13 +190,12 @@ fn main() -> ! {
         sw_ints.software_interrupt0,
         sw_ints.software_interrupt1,
         unsafe { &mut *addr_of_mut!(APP_CORE_STACK) },
-        || {
-            let debug = cfg!(feature = "debug-matrix") || keyboard::is_debug_mode();
+        move || {
             let signal = &*make_static!(Signal<CriticalSectionRawMutex, KeyboardReport>, Signal::new());
             let executor = make_static!(Executor, Executor::new());
 
             if debug {
-                log::info!("Booting in debug mode (Fn+D to switch back)");
+                ::log::info!("Booting in debug mode (Fn+D to switch back)");
                 executor.run(|spawner| {
                     spawner.must_spawn(keyboard::matrix(columns, rows, signal));
                     spawner.must_spawn(keyboard::debug_consumer(signal));
@@ -235,7 +238,7 @@ fn main() -> ! {
             };
             let now = SystemTimer::unit_value(esp_hal::timer::systimer::Unit::Unit0);
             lcd_fill(&mut spi, pixels);
-            log::trace!(
+            ::log::trace!(
                 "Time to fill display: {}ms",
                 (SystemTimer::unit_value(esp_hal::timer::systimer::Unit::Unit0) - now)
                     / (SystemTimer::ticks_per_second() / 1024)
@@ -244,7 +247,7 @@ fn main() -> ! {
             let now = SystemTimer::unit_value(esp_hal::timer::systimer::Unit::Unit0);
             if now.wrapping_sub(start) > SystemTimer::ticks_per_second() {
                 start = now;
-                log::info!("FPS: {}", frames);
+                ::log::info!("FPS: {}", frames);
                 frames = 0;
             }
         }

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -79,7 +79,7 @@ fn main() -> ! {
 
     // Check for panic from previous boot — message will be sent over USB CDC once enumerated
     if panic::check_previous_panic() {
-        ::log::warn!("Previous panic detected — will send details over USB CDC");
+        warn!("Previous panic detected — will send details over USB CDC");
     }
 
     // Note: the USB_EXCHG_PINS efuse pullup workaround is handled automatically
@@ -135,7 +135,7 @@ fn main() -> ! {
     for (cmd, data) in WEA2012_INIT_CMDS {
         lcd_write_cmd(&mut spi, *cmd, data);
     }
-    ::log::info!("Finished initializing display!");
+    info!("Finished initializing display!");
 
     let pixels = unsafe { &mut *addr_of_mut!(FRAME_BUFFER) };
     /*
@@ -182,7 +182,7 @@ fn main() -> ! {
             let executor = make_static!(Executor, Executor::new());
 
             if debug {
-                ::log::info!("Booting in debug mode (Fn+D to switch back)");
+                info!("Booting in debug mode (Fn+D to switch back)");
                 executor.run(|spawner| {
                     spawner.must_spawn(keyboard::matrix(columns, rows, signal));
                     spawner.must_spawn(keyboard::debug_consumer(signal));
@@ -225,7 +225,7 @@ fn main() -> ! {
             };
             let now = SystemTimer::unit_value(esp_hal::timer::systimer::Unit::Unit0);
             lcd_fill(&mut spi, pixels);
-            ::log::trace!(
+            trace!(
                 "Time to fill display: {}ms",
                 (SystemTimer::unit_value(esp_hal::timer::systimer::Unit::Unit0) - now)
                     / (SystemTimer::ticks_per_second() / 1024)
@@ -234,7 +234,7 @@ fn main() -> ! {
             let now = SystemTimer::unit_value(esp_hal::timer::systimer::Unit::Unit0);
             if now.wrapping_sub(start) > SystemTimer::ticks_per_second() {
                 start = now;
-                ::log::info!("FPS: {}", frames);
+                info!("FPS: {}", frames);
                 frames = 0;
             }
         }

--- a/firmware/src/panic.rs
+++ b/firmware/src/panic.rs
@@ -1,5 +1,6 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 const PANIC_MAGIC: u32 = 0x50414E43; // "PANC"
 const MAX_MSG_LEN: usize = 250;
@@ -12,6 +13,11 @@ const BUF_SIZE: usize = 4 + 2 + MAX_MSG_LEN;
 #[used]
 #[link_section = ".noinit"]
 static mut PANIC_BUF: [u8; BUF_SIZE] = [0u8; BUF_SIZE];
+
+/// Copy of the panic message for deferred CDC output.
+static PANIC_AVAILABLE: AtomicBool = AtomicBool::new(false);
+static mut PANIC_MSG_COPY: [u8; MAX_MSG_LEN] = [0u8; MAX_MSG_LEN];
+static mut PANIC_MSG_LEN: usize = 0;
 
 struct PanicWriter {
     offset: usize,
@@ -46,27 +52,48 @@ fn panic(info: &PanicInfo) -> ! {
 }
 
 /// Check for a stored panic message from a previous boot.
-/// If found, prints it over JTAG serial and clears it.
-/// Call this early in main(), before USB OTG takes over the serial pins.
-pub fn check_previous_panic() {
+/// If found, copies the message for later CDC output and prints over JTAG serial.
+/// Returns `true` if a panic was found.
+pub fn check_previous_panic() -> bool {
     let buf = unsafe { &mut *core::ptr::addr_of_mut!(PANIC_BUF) };
 
     let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
     if magic != PANIC_MAGIC {
-        return;
+        return false;
     }
 
     let len = u16::from_le_bytes(buf[4..6].try_into().unwrap()) as usize;
     let len = len.min(MAX_MSG_LEN);
 
-    // Clear magic before printing (in case printing itself panics)
+    // Clear magic early (safety: prevents recursive panic from re-reading this)
     buf[0..4].fill(0);
 
+    // Copy message for deferred CDC output
+    unsafe {
+        PANIC_MSG_COPY[..len].copy_from_slice(&buf[6..6 + len]);
+        PANIC_MSG_LEN = len;
+    }
+    PANIC_AVAILABLE.store(true, Ordering::Release);
+
+    // Also print over JTAG serial (works in debug mode / early boot)
     if let Ok(msg) = core::str::from_utf8(&buf[6..6 + len]) {
-        log::error!("========== PREVIOUS PANIC ==========");
-        log::error!("{}", msg);
-        log::error!("====================================");
-        // JTAG serial FIFO is small — give it time to drain before USB OTG takes over
+        // Use the JTAG serial writer directly (logger may not be initialized yet)
+        crate::log::jtag_serial_write(b"========== PREVIOUS PANIC ==========\r\n");
+        crate::log::jtag_serial_write(msg.as_bytes());
+        crate::log::jtag_serial_write(b"\r\n====================================\r\n");
         esp_hal::delay::Delay::new().delay_millis(100u32);
     }
+
+    true
+}
+
+/// Take the saved panic message (one-shot). Returns `None` if no panic or already taken.
+/// Used by the CDC writer to send the message over USB after enumeration.
+pub fn take_panic_message() -> Option<&'static str> {
+    if !PANIC_AVAILABLE.swap(false, Ordering::Acquire) {
+        return None;
+    }
+    let len = unsafe { PANIC_MSG_LEN };
+    let buf = unsafe { &*core::ptr::addr_of!(PANIC_MSG_COPY) };
+    core::str::from_utf8(&buf[..len]).ok()
 }

--- a/firmware/src/panic.rs
+++ b/firmware/src/panic.rs
@@ -1,27 +1,30 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
-// RTC slow memory on ESP32-S3: 0x5000_0000 - 0x5000_1FFF (8KB)
-// We use offset 0x1000 to avoid conflicting with ULP or bootloader usage
-const PANIC_MEM: *mut u8 = 0x5000_1000 as *mut u8;
 const PANIC_MAGIC: u32 = 0x50414E43; // "PANC"
 const MAX_MSG_LEN: usize = 250;
 
 // Layout: [magic: u32][len: u16][message: u8; MAX_MSG_LEN]
+const BUF_SIZE: usize = 4 + 2 + MAX_MSG_LEN;
 
-struct RtcWriter {
+/// Panic buffer in main SRAM. Placed in `.noinit` so the bootloader won't
+/// zero it on software reset — the previous contents survive across reboots.
+#[used]
+#[link_section = ".noinit"]
+static mut PANIC_BUF: [u8; BUF_SIZE] = [0u8; BUF_SIZE];
+
+struct PanicWriter {
     offset: usize,
 }
 
-impl Write for RtcWriter {
+impl Write for PanicWriter {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(PANIC_BUF) };
         for byte in s.bytes() {
             if self.offset >= MAX_MSG_LEN {
                 break;
             }
-            unsafe {
-                PANIC_MEM.add(6 + self.offset).write_volatile(byte);
-            }
+            buf[6 + self.offset] = byte;
             self.offset += 1;
         }
         Ok(())
@@ -30,40 +33,36 @@ impl Write for RtcWriter {
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
-    // Save panic message to RTC slow memory (survives software reset)
-    let mut writer = RtcWriter { offset: 0 };
+    let buf = unsafe { &mut *core::ptr::addr_of_mut!(PANIC_BUF) };
+
+    let mut writer = PanicWriter { offset: 0 };
     let _ = write!(writer, "{}", info);
 
-    unsafe {
-        // Write length then magic (magic last so partial writes aren't read as valid)
-        (PANIC_MEM.add(4) as *mut u16).write_volatile(writer.offset as u16);
-        (PANIC_MEM as *mut u32).write_volatile(PANIC_MAGIC);
-    }
+    // Write length then magic (magic last so partial writes aren't read as valid)
+    buf[4..6].copy_from_slice(&(writer.offset as u16).to_le_bytes());
+    buf[0..4].copy_from_slice(&PANIC_MAGIC.to_le_bytes());
 
     esp_hal::system::software_reset();
 }
 
-/// Check RTC slow memory for a stored panic message from a previous boot.
+/// Check for a stored panic message from a previous boot.
 /// If found, prints it over JTAG serial and clears it.
 /// Call this early in main(), before USB OTG takes over the serial pins.
 pub fn check_previous_panic() {
-    let magic = unsafe { (PANIC_MEM as *mut u32).read_volatile() };
+    let buf = unsafe { &mut *core::ptr::addr_of_mut!(PANIC_BUF) };
+
+    let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
     if magic != PANIC_MAGIC {
         return;
     }
 
-    let len = unsafe { (PANIC_MEM.add(4) as *mut u16).read_volatile() } as usize;
+    let len = u16::from_le_bytes(buf[4..6].try_into().unwrap()) as usize;
     let len = len.min(MAX_MSG_LEN);
 
-    let mut buf = [0u8; MAX_MSG_LEN];
-    for i in 0..len {
-        buf[i] = unsafe { PANIC_MEM.add(6 + i).read_volatile() };
-    }
+    // Clear magic before printing (in case printing itself panics)
+    buf[0..4].fill(0);
 
-    // Clear before printing (in case printing itself panics)
-    unsafe { (PANIC_MEM as *mut u32).write_volatile(0) };
-
-    if let Ok(msg) = core::str::from_utf8(&buf[..len]) {
+    if let Ok(msg) = core::str::from_utf8(&buf[6..6 + len]) {
         log::error!("========== PREVIOUS PANIC ==========");
         log::error!("{}", msg);
         log::error!("====================================");

--- a/firmware/src/panic.rs
+++ b/firmware/src/panic.rs
@@ -75,15 +75,6 @@ pub fn check_previous_panic() -> bool {
     }
     PANIC_AVAILABLE.store(true, Ordering::Release);
 
-    // Also print over JTAG serial (works in debug mode / early boot)
-    if let Ok(msg) = core::str::from_utf8(&buf[6..6 + len]) {
-        // Use the JTAG serial writer directly (logger may not be initialized yet)
-        crate::log::jtag_serial_write(b"========== PREVIOUS PANIC ==========\r\n");
-        crate::log::jtag_serial_write(msg.as_bytes());
-        crate::log::jtag_serial_write(b"\r\n====================================\r\n");
-        esp_hal::delay::Delay::new().delay_millis(100u32);
-    }
-
     true
 }
 


### PR DESCRIPTION
## Summary
- USB composite device: HID keyboard + CDC ACM serial port for log output
- Custom `log` backend (`logger.rs`): formats to pipe, consumer drains to CDC (normal) or JTAG serial (debug)
- Custom panic handler (`panic.rs`): saves message to `.noinit` SRAM, sends over CDC on next boot
- Removes `esp-println` and `esp-backtrace` dependencies — logging and panic handling fully self-contained
- Debug mode (`debug-matrix`/Fn+D) creates `UsbSerialJtag` and drains log pipe to JTAG serial instead

## Test plan
- [ ] Normal mode: keyboard works, `/dev/ttyACM0` shows log output
- [ ] Debug mode (`--features debug-matrix`): JTAG serial shows logs
- [ ] Trigger a panic: next boot sends previous panic message over CDC
- [ ] Fn+D toggles between modes
- [ ] No boot crash with 4K app core stack