### PR TITLE
add M1.4 bolt + hex nut overlay retention

### DIFF
--- a/3d/case/README.md
+++ b/3d/case/README.md
@@ -239,20 +239,24 @@ When `ENABLE_SCREW_INSERTS=true` (and `ENABLE_MAGNET_POCKETS=false`), the
 overlay is secured by four M1.6 bolts threading up from inside the tray
 into hex nuts glued into the overlay. Nothing is visible externally.
 
-#### Hardware (4 of each)
+#### Hardware (4 nuts + 2 bolt lengths)
 
-| Part | Specification | Key dimensions |
-|------|---------------|----------------|
-| Hex nut | M1.6 DIN 934 | 3.2 mm across-flats, 1.3 mm thick |
-| Socket head cap screw | M1.6 × 3 mm ISO 4762 | 3.0 mm head dia, 1.6 mm head height |
+| Qty | Part | Specification | Key dimensions |
+|-----|------|---------------|----------------|
+| 4 | Hex nut | M1.6 DIN 934 | 3.2 mm across-flats, 1.3 mm thick |
+| 2 | Socket head cap screw | M1.6 × 16 mm | Front corners |
+| 2 | Socket head cap screw | M1.6 × 25 mm | Back corners |
 
-The 3 mm bolt length is load-bearing: the tilt-compensated counterbore is
-1.78 mm deep at the bolt center (not the nominal 1.5 mm — see comment in
-`case.scad`), leaving 1.22 mm of shaft for the 1.3 mm nut (97% engagement).
-A 4 mm bolt would overshoot the nut pocket ceiling and prevent the overlay
-from seating. The traverse is identical at all 4 positions — the 6° tilt
-shifts both the counterbore and mating surface equally, so front and back
-bolts are the same length.
+The 6° tilt makes the front wall ~15 mm and back wall ~27 mm tall, so
+front and back bolts are different lengths. The bolts enter from the tray
+underside (desk-facing bottom), pass up through the wall columns, and
+thread into the nuts in the overlay. The nut pocket is deepened to 2.5 mm
+(vs the 1.3 mm nut) to widen the bolt-length tolerance window:
+
+| Position | Bolt window | Standard size | Ceiling clearance |
+|----------|-------------|---------------|-------------------|
+| Front (×2) | 13.85–16.35 mm | 16 mm | 0.35 mm |
+| Back (×2) | 25.00–27.50 mm | 25 mm | 2.50 mm |
 
 #### Nut installation
 
@@ -270,9 +274,13 @@ bolts are the same length.
 #### Final assembly
 
 1. Complete the gasket + plate install (see above).
-2. Seat the overlay on the tray wall tops.
-3. From inside the tray cavity, thread each M1.6 bolt up through the
-   clearance hole and counterbore into the nut above. Tighten with a
-   1.3 mm hex key — finger-tight plus a quarter turn is sufficient.
+2. Seat the overlay on the tray wall tops (nuts face down, aligning
+   with the clearance holes in the tray walls).
+3. Flip the assembled case upside-down.
+4. Insert the 16 mm bolts into the two front-corner counterbores and
+   the 25 mm bolts into the two back-corner counterbores. Tighten with
+   a 1.3 mm hex key — finger-tight plus a quarter turn is sufficient.
    Do not overtorque; the resin threads no load, but the nut cheek
    is 0.7 mm nominal.
+5. Flip the case back upright. The bolt heads sit flush in the
+   counterbores on the tray underside, hidden against the desk.

--- a/3d/case/README.md
+++ b/3d/case/README.md
@@ -58,6 +58,7 @@ The main toggles in `case.scad` control which features are included:
 | `PRINT_SUPPORTS` | `false` | Add internal anti-warp rib walls to tray (print mode only) |
 | `ENABLE_OVERLAY_RABBET` | `true` | Locating tongue/recess for X/Y registration |
 | `ENABLE_MAGNET_POCKETS` | `true` | Blind magnet pockets for overlay hold-down |
+| `ENABLE_SCREW_INSERTS` | `false` | M1.6 bolt + glued hex nut overlay retention (mutually exclusive with magnets) |
 | `ENABLE_DECORATIVE_TRIMS` | `true` | Debossed logos, pinstripe, initials |
 
 ## JLC3DP SLA submission notes
@@ -83,11 +84,11 @@ Missing any of these will compromise fit or finish.
 > **OVERLAY (mkey_overlay.stl):**
 > - Orient cosmetic-face DOWN on the build plate (the face with the key
 >   openings and display window). The underside, which carries the magnet
->   pockets, faces up.
+>   pockets (or hex nut pockets if using screw retention), faces up.
 > - Place factory supports **only on the outer vertical side walls.** No
 >   point supports on the downward-facing cosmetic face (key openings,
 >   display window rim, pinstripe groove) and no supports inside the magnet
->   pockets or display pocket on the up-facing underside. A raft under the
+>   pockets, hex nut pockets, or display pocket on the up-facing underside. A raft under the
 >   cosmetic face is acceptable provided the pinstripe groove and key
 >   openings drain during post-processing (we IPA-flush these on our end).
 > - **Apply X-axis scale compensation on this piece as well** — it must
@@ -231,3 +232,47 @@ removable, lower the overlay onto the tray dry (no gaskets, no plate).
 All six pairs should click together. If any pair repels, pop that
 magnet out and flip it — catching this before the CA sets is much
 cheaper than after.
+
+### Screw + nut retention (alternative to magnets)
+
+When `ENABLE_SCREW_INSERTS=true` (and `ENABLE_MAGNET_POCKETS=false`), the
+overlay is secured by four M1.6 bolts threading up from inside the tray
+into hex nuts glued into the overlay. Nothing is visible externally.
+
+#### Hardware (4 of each)
+
+| Part | Specification | Key dimensions |
+|------|---------------|----------------|
+| Hex nut | M1.6 DIN 934 | 3.2 mm across-flats, 1.3 mm thick |
+| Socket head cap screw | M1.6 × 3 mm ISO 4762 | 3.0 mm head dia, 1.6 mm head height |
+
+The 3 mm bolt length is load-bearing: the tilt-compensated counterbore is
+1.78 mm deep at the bolt center (not the nominal 1.5 mm — see comment in
+`case.scad`), leaving 1.22 mm of shaft for the 1.3 mm nut (97% engagement).
+A 4 mm bolt would overshoot the nut pocket ceiling and prevent the overlay
+from seating. The traverse is identical at all 4 positions — the 6° tilt
+shifts both the counterbore and mating surface equally, so front and back
+bolts are the same length.
+
+#### Nut installation
+
+1. **Dry-fit first.** Drop each nut into its hex pocket on the overlay
+   underside and confirm it sits flush or slightly below the surface.
+   The hex shape should prevent rotation by hand. If a nut is tight,
+   ream the pocket lightly with a needle file — do not force it.
+2. **Glue with gel-type CA.** Apply a thin ring of gel CA around the
+   pocket wall, press the nut in, and hold for 10 seconds. Wipe any
+   squeeze-out immediately — excess CA on the overlay seating face will
+   prevent the overlay from sitting flat on the tray.
+3. **Do not use heat-set inserts.** SLA resin warps under soldering-iron
+   temperatures. Glued hex nuts are the correct fastener for this process.
+
+#### Final assembly
+
+1. Complete the gasket + plate install (see above).
+2. Seat the overlay on the tray wall tops.
+3. From inside the tray cavity, thread each M1.6 bolt up through the
+   clearance hole and counterbore into the nut above. Tighten with a
+   1.3 mm hex key — finger-tight plus a quarter turn is sufficient.
+   Do not overtorque; the resin threads no load, but the nut cheek
+   is 0.7 mm nominal.

--- a/3d/case/README.md
+++ b/3d/case/README.md
@@ -75,9 +75,10 @@ Missing any of these will compromise fit or finish.
 > - Internal anti-warp ribs are already modelled inside the cavity — **do
 >   not add factory supports inside the cavity.** Factory supports on the
 >   outer side walls and outer bottom are acceptable.
-> - The outer left and right side walls each carry a debossed "mKey" logo
->   centred at mid-height, mid-length (~30 × 7 mm footprint). Please keep
->   factory support contact points clear of that debossed region if possible.
+> - The outer back wall carries a debossed "mKey" logo centred
+>   horizontally, vertically between the bottom chamfer and the wall top
+>   (~30 × 7 mm footprint). Please keep factory support contact points
+>   clear of that debossed region if possible.
 > - **Apply X-axis scale compensation on this piece** — it is a 363 mm long
 >   part with critical tab-alignment slot features at both X extremes.
 >

--- a/3d/case/README.md
+++ b/3d/case/README.md
@@ -239,24 +239,17 @@ When `ENABLE_SCREW_INSERTS=true` (and `ENABLE_MAGNET_POCKETS=false`), the
 overlay is secured by four M1.6 bolts threading up from inside the tray
 into hex nuts glued into the overlay. Nothing is visible externally.
 
-#### Hardware (4 nuts + 2 bolt lengths)
+#### Hardware (4 of each)
 
 | Qty | Part | Specification | Key dimensions |
 |-----|------|---------------|----------------|
 | 4 | Hex nut | M1.6 DIN 934 | 3.2 mm across-flats, 1.3 mm thick |
-| 2 | Socket head cap screw | M1.6 × 16 mm | Front corners |
-| 2 | Socket head cap screw | M1.6 × 25 mm | Back corners |
+| 4 | Socket head cap screw | M1.6 × 3 mm | 3.0 mm head dia, 1.6 mm head height |
 
-The 6° tilt makes the front wall ~15 mm and back wall ~27 mm tall, so
-front and back bolts are different lengths. The bolts enter from the tray
-underside (desk-facing bottom), pass up through the wall columns, and
-thread into the nuts in the overlay. The nut pocket is deepened to 2.5 mm
-(vs the 1.3 mm nut) to widen the bolt-length tolerance window:
-
-| Position | Bolt window | Standard size | Ceiling clearance |
-|----------|-------------|---------------|-------------------|
-| Front (×2) | 13.85–16.35 mm | 16 mm | 0.35 mm |
-| Back (×2) | 25.00–27.50 mm | 25 mm | 2.50 mm |
+Same bolt length at all 4 positions. The bolt is a captive pin inserted
+from the wall top — head catches on a step 3.2 mm below the surface,
+shaft protrudes 1.5 mm above for full nut engagement (1.3 mm + 0.2 mm).
+Total hole depth 3.2 mm, within JLC3DP SLA limits (max 6 mm for 2 mm dia).
 
 #### Nut installation
 
@@ -274,13 +267,12 @@ thread into the nuts in the overlay. The nut pocket is deepened to 2.5 mm
 #### Final assembly
 
 1. Complete the gasket + plate install (see above).
-2. Seat the overlay on the tray wall tops (nuts face down, aligning
-   with the clearance holes in the tray walls).
-3. Flip the assembled case upside-down.
-4. Insert the 16 mm bolts into the two front-corner counterbores and
-   the 25 mm bolts into the two back-corner counterbores. Tighten with
-   a 1.3 mm hex key — finger-tight plus a quarter turn is sufficient.
-   Do not overtorque; the resin threads no load, but the nut cheek
-   is 0.7 mm nominal.
-5. Flip the case back upright. The bolt heads sit flush in the
-   counterbores on the tray underside, hidden against the desk.
+2. Drop 4× M1.6 × 3 mm bolts into the tray wall-top holes (tip-first
+   from above — the shaft passes through the narrow clearance section,
+   the head catches on the wider counterbore step below).
+3. Place the overlay on the tray — the bolt tips protruding above the
+   wall tops snap into the glued hex nuts, mechanically locking the
+   overlay. No tightening needed.
+4. To remove the overlay: push each bolt down through the clearance
+   hole with a thin pin or probe (e.g. a 1.5 mm hex key), disengaging
+   the tip from the nut. Then lift the overlay off.

--- a/3d/case/README.md
+++ b/3d/case/README.md
@@ -244,18 +244,21 @@ into hex nuts glued into the overlay. Nothing is visible externally.
 | Qty | Part | Specification | Key dimensions |
 |-----|------|---------------|----------------|
 | 4 | Hex nut | M1.6 DIN 934 | 3.2 mm across-flats, 1.3 mm thick |
-| 4 | Socket head cap screw | M1.6 × 8 mm | 3.0 mm head dia, 1.6 mm head height |
+| 4 | Socket head cap screw | M1.6 × 12 mm | 3.0 mm head dia, 1.6 mm head height |
 
 Same bolt length at all 4 positions. The bolt threads up from the tray
 underside through the wall column and into the overlay nut. The through-
-hole is printed as two segments that meet in the middle — no post-print
-drilling required:
-- **Pocket** (5 mm dia, from tray bottom upward): bolt head sits here
-- **Clearance** (2 mm dia, from wall top downward): bolt shaft passes here
+hole is a 3-segment stepped bore — no post-print drilling required:
+- **Pocket** (3.3 mm dia, from tray bottom upward): bolt head sits here
+- **Mid** (2.5 mm dia, intermediate): extends printable depth
+- **Clearance** (2.0 mm dia, from wall top downward): shaft exits here
 
-Both segments stay within JLC3DP SLA depth limits (max 3× diameter).
-At the back corners, the 10 mm chamfer removes the tray bottom; the
-pocket starts from the chamfer face (deboss, not a protrusion).
+Each segment stays within JLC3DP SLA depth limits (max 3× diameter)
+and within the 4.8 mm wall width. The bolt head catches on the
+pocket-to-mid step. At the back corners, the 10 mm chamfer removes
+the tray bottom; the pocket starts from the chamfer face (deboss).
+Small reinforcement pads on the tray cavity inner face provide
+structural support around the bore.
 
 #### Nut installation
 

--- a/3d/case/README.md
+++ b/3d/case/README.md
@@ -58,7 +58,7 @@ The main toggles in `case.scad` control which features are included:
 | `PRINT_SUPPORTS` | `false` | Add internal anti-warp rib walls to tray (print mode only) |
 | `ENABLE_OVERLAY_RABBET` | `true` | Locating tongue/recess for X/Y registration |
 | `ENABLE_MAGNET_POCKETS` | `true` | Blind magnet pockets for overlay hold-down |
-| `ENABLE_SCREW_INSERTS` | `false` | M1.6 bolt + glued hex nut overlay retention (mutually exclusive with magnets) |
+| `ENABLE_SCREW_INSERTS` | `false` | M1.4 bolt + glued hex nut overlay retention (mutually exclusive with magnets) |
 | `ENABLE_DECORATIVE_TRIMS` | `true` | Debossed logos, pinstripe, initials |
 
 ## JLC3DP SLA submission notes
@@ -236,29 +236,28 @@ cheaper than after.
 ### Screw + nut retention (alternative to magnets)
 
 When `ENABLE_SCREW_INSERTS=true` (and `ENABLE_MAGNET_POCKETS=false`), the
-overlay is secured by four M1.6 bolts threading up from inside the tray
-into hex nuts glued into the overlay. Nothing is visible externally.
+overlay is secured by four M1.4 bolts threading up from inside the tray
+into hex nuts glued into the overlay. Nothing is visible externally — bolt
+heads sit in pockets on the tray underside (hidden against the desk),
+and the overlay top surface is flush.
 
 #### Hardware (4 of each)
 
 | Qty | Part | Specification | Key dimensions |
 |-----|------|---------------|----------------|
-| 4 | Hex nut | M1.6 DIN 934 | 3.2 mm across-flats, 1.3 mm thick |
-| 4 | Socket head cap screw | M1.6 × 12 mm | 3.0 mm head dia, 1.6 mm head height |
+| 4 | Hex nut | M1.4 DIN 934 | 3.0 mm across-flats, 1.2 mm thick |
+| 4 | Socket head cap screw | M1.4 × 12 mm | 2.6 mm head dia, 1.4 mm head height |
 
 Same bolt length at all 4 positions. The bolt threads up from the tray
 underside through the wall column and into the overlay nut. The through-
 hole is a 3-segment stepped bore — no post-print drilling required:
-- **Pocket** (3.3 mm dia, from tray bottom upward): bolt head sits here
-- **Mid** (2.5 mm dia, intermediate): extends printable depth
+- **Pocket** (3.0 mm dia, from tray bottom upward): bolt head sits here
+- **Mid** (2.5 mm dia, intermediate): extends the printable depth
 - **Clearance** (2.0 mm dia, from wall top downward): shaft exits here
 
-Each segment stays within JLC3DP SLA depth limits (max 3× diameter)
-and within the 4.8 mm wall width. The bolt head catches on the
-pocket-to-mid step. At the back corners, the 10 mm chamfer removes
-the tray bottom; the pocket starts from the chamfer face (deboss).
-Small reinforcement pads on the tray cavity inner face provide
-structural support around the bore.
+Each segment stays within JLC3DP SLA depth limits (max 3× diameter).
+At the back corners, the 10 mm chamfer removes the tray bottom; the
+pocket starts from the chamfer face (deboss).
 
 #### Nut installation
 
@@ -279,8 +278,8 @@ structural support around the bore.
 2. Seat the overlay on the tray wall tops (nuts face down, aligning
    with the clearance holes in the tray walls).
 3. Flip the assembled case upside-down.
-4. Insert the M1.6 × 8 mm bolts into all 4 pocket holes from below
-   and tighten into the overlay nuts with a 1.3 mm hex key. Finger-
+4. Insert the M1.4 × 12 mm bolts into all 4 pocket holes from below
+   and tighten into the overlay nuts with a 1.25 mm hex key. Finger-
    tight plus a quarter turn is sufficient.
 5. Flip the case back upright. The bolt heads sit in the pocket
    recesses on the tray underside, hidden against the desk.

--- a/3d/case/README.md
+++ b/3d/case/README.md
@@ -244,12 +244,18 @@ into hex nuts glued into the overlay. Nothing is visible externally.
 | Qty | Part | Specification | Key dimensions |
 |-----|------|---------------|----------------|
 | 4 | Hex nut | M1.6 DIN 934 | 3.2 mm across-flats, 1.3 mm thick |
-| 4 | Socket head cap screw | M1.6 × 3 mm | 3.0 mm head dia, 1.6 mm head height |
+| 4 | Socket head cap screw | M1.6 × 8 mm | 3.0 mm head dia, 1.6 mm head height |
 
-Same bolt length at all 4 positions. The bolt is a captive pin inserted
-from the wall top — head catches on a step 3.2 mm below the surface,
-shaft protrudes 1.5 mm above for full nut engagement (1.3 mm + 0.2 mm).
-Total hole depth 3.2 mm, within JLC3DP SLA limits (max 6 mm for 2 mm dia).
+Same bolt length at all 4 positions. The bolt threads up from the tray
+underside through the wall column and into the overlay nut. The through-
+hole is printed as two segments that meet in the middle — no post-print
+drilling required:
+- **Pocket** (5 mm dia, from tray bottom upward): bolt head sits here
+- **Clearance** (2 mm dia, from wall top downward): bolt shaft passes here
+
+Both segments stay within JLC3DP SLA depth limits (max 3× diameter).
+At the back corners, the 10 mm chamfer removes the tray bottom; the
+pocket starts from the chamfer face (deboss, not a protrusion).
 
 #### Nut installation
 
@@ -267,12 +273,11 @@ Total hole depth 3.2 mm, within JLC3DP SLA limits (max 6 mm for 2 mm dia).
 #### Final assembly
 
 1. Complete the gasket + plate install (see above).
-2. Drop 4× M1.6 × 3 mm bolts into the tray wall-top holes (tip-first
-   from above — the shaft passes through the narrow clearance section,
-   the head catches on the wider counterbore step below).
-3. Place the overlay on the tray — the bolt tips protruding above the
-   wall tops snap into the glued hex nuts, mechanically locking the
-   overlay. No tightening needed.
-4. To remove the overlay: push each bolt down through the clearance
-   hole with a thin pin or probe (e.g. a 1.5 mm hex key), disengaging
-   the tip from the nut. Then lift the overlay off.
+2. Seat the overlay on the tray wall tops (nuts face down, aligning
+   with the clearance holes in the tray walls).
+3. Flip the assembled case upside-down.
+4. Insert the M1.6 × 8 mm bolts into all 4 pocket holes from below
+   and tighten into the overlay nuts with a 1.3 mm hex key. Finger-
+   tight plus a quarter turn is sufficient.
+5. Flip the case back upright. The bolt heads sit in the pocket
+   recesses on the tray underside, hidden against the desk.

--- a/3d/case/build_stl.sh
+++ b/3d/case/build_stl.sh
@@ -1,21 +1,31 @@
 #!/usr/bin/env bash
 # build_stl.sh — Export print-ready STLs from case.scad using OpenSCAD CLI.
 #
+# Produces four STLs by default — one tray + one overlay for each retention
+# scheme (magnets and screws) — since both retention variants get fabricated
+# from the same order and the mating underside pockets differ between them:
+#
+#   mkey_tray_magnets.stl     tray with magnet pockets in wall tops
+#   mkey_overlay_magnets.stl  overlay with magnet pockets in underside
+#   mkey_tray_screws.stl      tray with 3-segment stepped bolt bores
+#   mkey_overlay_screws.stl   overlay with hex nut pockets in underside
+#
 # Usage:
 #   ./build_stl.sh [OPTIONS]
 #
 # Options:
-#   --piece tray|overlay|both   Which piece(s) to export (default: both)
-#   --supports                  Add breakaway cross-braces to the tray
-#   --fn N                      Override circle resolution (default: 128)
-#   --outdir DIR                Output directory (default: current directory)
-#   -h, --help                  Show this help message
+#   --piece tray|overlay|both       Which piece(s) to export (default: both)
+#   --retention magnets|screws|both Which retention variant(s) (default: both)
+#   --supports                      Add breakaway cross-braces to the tray
+#   --fn N                          Override circle resolution (default: 128)
+#   --outdir DIR                    Output directory (default: current directory)
+#   -h, --help                      Show this help message
 #
 # Examples:
-#   ./build_stl.sh                          # Export both pieces, no supports
-#   ./build_stl.sh --supports               # Export both, tray with braces
-#   ./build_stl.sh --piece overlay          # Export only the overlay
-#   ./build_stl.sh --supports --fn 96       # Faster render with lower resolution
+#   ./build_stl.sh                            # All 4 STLs, no supports
+#   ./build_stl.sh --supports                 # All 4, tray with anti-warp ribs
+#   ./build_stl.sh --retention magnets        # Magnet pair only
+#   ./build_stl.sh --piece tray --retention screws  # Just the screw tray
 
 set -euo pipefail
 
@@ -24,6 +34,7 @@ SCAD_FILE="$SCRIPT_DIR/case.scad"
 
 # Defaults
 PIECE="both"
+RETENTION="both"
 SUPPORTS="false"
 FN=128
 OUTDIR="."
@@ -35,14 +46,25 @@ usage() {
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --piece)    PIECE="$2"; shift 2 ;;
-        --supports) SUPPORTS="true"; shift ;;
-        --fn)       FN="$2"; shift 2 ;;
-        --outdir)   OUTDIR="$2"; shift 2 ;;
-        -h|--help)  usage ;;
-        *)          echo "Unknown option: $1" >&2; exit 1 ;;
+        --piece)     PIECE="$2"; shift 2 ;;
+        --retention) RETENTION="$2"; shift 2 ;;
+        --supports)  SUPPORTS="true"; shift ;;
+        --fn)        FN="$2"; shift 2 ;;
+        --outdir)    OUTDIR="$2"; shift 2 ;;
+        -h|--help)   usage ;;
+        *)           echo "Unknown option: $1" >&2; exit 1 ;;
     esac
 done
+
+case "$PIECE" in
+    tray|overlay|both) ;;
+    *) echo "Error: --piece must be tray, overlay, or both" >&2; exit 1 ;;
+esac
+
+case "$RETENTION" in
+    magnets|screws|both) ;;
+    *) echo "Error: --retention must be magnets, screws, or both" >&2; exit 1 ;;
+esac
 
 if ! command -v openscad &>/dev/null; then
     echo "Error: openscad not found in PATH." >&2
@@ -54,16 +76,24 @@ mkdir -p "$OUTDIR"
 
 render_piece() {
     local piece="$1"
-    local outfile="$2"
+    local retention="$2"
+    local outfile="$3"
     local show_tray="false"
     local show_overlay="false"
+    local magnets="false"
+    local screws="false"
 
     case "$piece" in
         tray)    show_tray="true" ;;
         overlay) show_overlay="true" ;;
     esac
 
-    echo "Rendering $piece -> $outfile (fn=$FN, supports=$SUPPORTS) ..."
+    case "$retention" in
+        magnets) magnets="true" ;;
+        screws)  screws="true" ;;
+    esac
+
+    echo "Rendering $piece/$retention -> $outfile (fn=$FN, supports=$SUPPORTS) ..."
 
     openscad \
         -o "$outfile" \
@@ -73,27 +103,32 @@ render_piece() {
         -D "SHOW_PLATE=false" \
         -D "SHOW_DISPLAY=false" \
         -D "PRINT_SUPPORTS=$SUPPORTS" \
+        -D "ENABLE_MAGNET_POCKETS=$magnets" \
+        -D "ENABLE_SCREW_INSERTS=$screws" \
         -D "\$fn=$FN" \
         "$SCAD_FILE"
 
     echo "  Done: $outfile"
 }
 
+pieces=()
 case "$PIECE" in
-    tray)
-        render_piece tray "$OUTDIR/mkey_tray.stl"
-        ;;
-    overlay)
-        render_piece overlay "$OUTDIR/mkey_overlay.stl"
-        ;;
-    both)
-        render_piece tray "$OUTDIR/mkey_tray.stl"
-        render_piece overlay "$OUTDIR/mkey_overlay.stl"
-        ;;
-    *)
-        echo "Error: --piece must be tray, overlay, or both" >&2
-        exit 1
-        ;;
+    tray)    pieces=(tray) ;;
+    overlay) pieces=(overlay) ;;
+    both)    pieces=(tray overlay) ;;
 esac
+
+retentions=()
+case "$RETENTION" in
+    magnets) retentions=(magnets) ;;
+    screws)  retentions=(screws) ;;
+    both)    retentions=(magnets screws) ;;
+esac
+
+for retention in "${retentions[@]}"; do
+    for piece in "${pieces[@]}"; do
+        render_piece "$piece" "$retention" "$OUTDIR/mkey_${piece}_${retention}.stl"
+    done
+done
 
 echo "Build complete."

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -517,9 +517,10 @@ function magnet_positions() = [
 
 // ─── Screw + nut pockets (optional, ENABLE_SCREW_INSERTS) ───────────────────
 // M1.6 hex nuts glued into hex-shaped pockets in the overlay underside;
-// M1.6 bolts thread upward through clearance holes in the tray wall top.
-// The bolt heads sit in counterbores recessed below the wall top so the
-// overlay seats flat. The hex pocket prevents the nut from spinning during
+// M1.6 bolts thread upward from the tray underside (desk-facing bottom)
+// through clearance holes in the wall columns and into the overlay nuts.
+// The bolt heads sit in counterbores recessed into the tray bottom, hidden
+// against the desk. The hex pocket prevents the nut from spinning during
 // tightening; CA glue locks it permanently. 4 corners only — positive
 // mechanical engagement doesn't need mid-wall reinforcement to resist bow.
 //
@@ -527,27 +528,28 @@ function magnet_positions() = [
 // Glued hex nuts are the correct fastener for this process.
 //
 // Hardware: M1.6 hex nut DIN 934 (3.2 mm AF, 1.3 mm thick),
-//           M1.6 × 3 mm socket head cap screw.
-// Length stack-up: the tilt-compensated counterbore is 1.78 mm deep at
-// the bolt center (not the nominal 1.5 mm — the cylinder is anchored to
-// the uphill edge of the tilted wall top, so it cuts 0.28 mm deeper at
-// center). Full traverse to nut top = 1.78 + 1.3 = 3.08 mm. A 3 mm bolt
-// gives 97% nut engagement; 4 mm would overshoot the pocket ceiling.
-// The traverse is identical at all 4 positions (front and back) because
-// both the counterbore anchor and the mating surface shift linearly with
-// the tilt — the Y-dependence cancels.
+//           M1.6 × 16 mm SHCS for front corners,
+//           M1.6 × 25 mm SHCS for back corners.
+// The 6° tilt makes the front wall ~15 mm and back wall ~27 mm tall, so
+// front and back bolts are different lengths. The nut pocket is deepened
+// to 2.5 mm (1.0 mm overlay skin) to widen the bolt-length window enough
+// for standard sizes to fit:
+//   Front: window [13.85, 16.35] → M1.6 × 16 (0.35 mm ceiling clearance)
+//   Back:  window [25.00, 27.50] → M1.6 × 25 (2.50 mm ceiling clearance)
 screw_nut_af       = 3.4;    // hex pocket across-flats (3.2 mm M1.6 nut +
                              // 0.2 mm SLA dimensional tolerance). Oriented
                              // with flats parallel to wall faces so AF
                              // constrains the wall-thickness cheek.
-screw_nut_depth    = 1.5;    // hex pocket depth (1.3 mm nut + 0.2 mm glue
-                             // headroom). Leaves top_t − 1.5 = 2.0 mm of
-                             // solid overlay above the pocket.
-screw_clear_d      = 2.0;    // M1.6 clearance hole through tray wall top
-screw_head_d       = 3.5;    // counterbore diameter (M1.6 SHCS head OD
-                             // 3.0 mm + 0.5 mm clearance)
-screw_head_depth   = 1.5;    // counterbore depth — recesses bolt head below
-                             // wall top so it doesn't foul the overlay
+screw_nut_depth    = 2.5;    // hex pocket depth. Deeper than the 1.3 mm nut
+                             // to widen the bolt-length tolerance window for
+                             // standard bolt sizes entering from the tray
+                             // underside. Leaves top_t − 2.5 = 1.0 mm of
+                             // overlay skin above the pocket (structural,
+                             // not cosmetic — the pocket is over the wall).
+screw_clear_d      = 2.0;    // M1.6 clearance hole through tray wall column
+screw_head_d       = 3.5;    // counterbore diameter on tray underside (M1.6
+                             // SHCS head OD 3.0 mm + 0.5 mm clearance)
+screw_head_depth   = 1.5;    // counterbore depth into tray bottom
 screw_inset        = 13;     // corner inset (same geometry as magnet_inset)
 
 // Screw positions: 4 corners, same layout function pattern as magnet_positions.
@@ -1042,15 +1044,9 @@ assert(!ENABLE_SCREW_INSERTS || (tray_wall_t - screw_head_d) / 2 >= 0.8,
 // Hex pocket must not breach the overlay top surface.
 assert(!ENABLE_SCREW_INSERTS || screw_nut_depth <= top_t - 1.0,
        "hex nut pocket depth leaves < 1.0 mm of overlay skin above the pocket");
-// Counterbore must not breach the tray floor. Same tilt-compensation check
-// as magnet pockets: anchor to uphill edge.
-screw_tilt_drift = screw_head_d * tan(tilt_angle);
-screw_cb_cyl_h   = screw_head_depth + screw_tilt_drift + 0.2;
-assert(!ENABLE_SCREW_INSERTS ||
-       len([for (p = screw_positions())
-            if (top_z(p[1] + screw_head_d/2) - top_t + 0.1 - screw_cb_cyl_h
-                < bottom_t + 2.0) 1]) == 0,
-       "screw counterbore bottom leaves less than 2 mm of wall material above the case floor");
+// Counterbore on the tray underside must not breach the cavity floor.
+assert(!ENABLE_SCREW_INSERTS || screw_head_depth <= bottom_t - 1.0,
+       "screw counterbore depth exceeds bottom_t with < 1.0 mm floor remaining");
 // Every screw position must sit entirely inside the wall ring. Use the
 // hex across-corners as the bounding radius (conservative — the hex
 // vertices extend further than the flats).
@@ -1650,37 +1646,35 @@ module overlay_magnet_pockets() {
 }
 
 // ─── Screw + nut geometry (optional, ENABLE_SCREW_INSERTS) ─────────────────
-// Same tilt-compensation approach as magnet pockets: anchor the cutting
-// solid to the extreme wall-top over the feature footprint, extend by the
-// tilt drift so the full pocket depth is preserved at both edges.
+// Bolt enters from the tray underside (z=0), passes up through the wall
+// column, exits the wall top, and threads into a hex nut glued in the
+// overlay underside. Assembly: flip case upside-down, insert bolts, tighten.
 //
-// Tray: cylindrical counterbore (screw_head_d × screw_head_depth) at the
-//   wall top, plus a clearance through-hole (screw_clear_d) extending down
-//   into the cavity.
-// Overlay: hex-shaped blind pocket (screw_nut_af across-flats ×
-//   screw_nut_depth) cut from the overlay underside. The hex prevents the
-//   glued nut from rotating during bolt tightening. Flats are oriented
-//   parallel to the wall faces (default $fn=6 orientation has flats
-//   perpendicular to Y, which suits front/back wall positions).
+// Tray: counterbore (screw_head_d × screw_head_depth) at the tray underside
+//   (flat, no tilt compensation needed), plus a clearance through-hole
+//   (screw_clear_d) from the counterbore top all the way up through the
+//   wall to above the tilted wall top.
+// Overlay: hex-shaped blind pocket (screw_nut_af × screw_nut_depth) cut
+//   from the overlay underside, with tilt compensation as per magnet pockets.
 
-// Tilt-drift values for the screw features (same formula as magnet pockets).
-screw_nut_tilt_drift  = screw_nut_ac * tan(tilt_angle);
-screw_nut_cyl_h       = screw_nut_depth + screw_nut_tilt_drift + 0.2;
-screw_head_tilt_drift = screw_head_d * tan(tilt_angle);
-screw_head_cyl_h      = screw_head_depth + screw_head_tilt_drift + 0.2;
+// Tilt-drift values for the overlay nut pocket.
+screw_nut_tilt_drift = screw_nut_ac * tan(tilt_angle);
+screw_nut_cyl_h      = screw_nut_depth + screw_nut_tilt_drift + 0.2;
 
 module tray_screw_holes() {
     for (p = screw_positions()) {
-        // Counterbore: top at uphill edge + 0.1 mm overshoot, extends down
-        // by head depth + drift.
-        z_top_hi = top_z(p[1] + screw_head_d/2) - top_t + 0.1;
-        translate([p[0], p[1], z_top_hi - screw_head_cyl_h])
-            cylinder(d = screw_head_d, h = screw_head_cyl_h);
-        // Clearance hole: from the bottom of the counterbore down through
-        // the wall into the cavity. Oversized length for a clean through-cut.
-        z_clear_top = z_top_hi - screw_head_cyl_h + 0.01;
-        translate([p[0], p[1], z_clear_top - 20])
-            cylinder(d = screw_clear_d, h = 20);
+        // Counterbore on tray underside: flat at z=0 (no tilt here).
+        // Extends upward from z = -0.1 (slight overshoot below bottom face)
+        // by screw_head_depth + 0.1.
+        translate([p[0], p[1], -0.1])
+            cylinder(d = screw_head_d, h = screw_head_depth + 0.1);
+        // Clearance hole: from top of counterbore up through the entire
+        // wall column to above the tilted wall top. Tilt compensation at
+        // the top: the hole must exit cleanly through the tilted surface,
+        // so extend well past the highest point of the wall top at this Y.
+        z_wall_top_hi = top_z(p[1] + screw_clear_d/2) - top_t + 0.1;
+        translate([p[0], p[1], screw_head_depth - 0.01])
+            cylinder(d = screw_clear_d, h = z_wall_top_hi - screw_head_depth + 0.02);
     }
 }
 

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -604,26 +604,26 @@ plate_oy = wall_t + plate_gap;
 // Bottom pocket: accepts the module body, cut from the overlay underside,
 // depth = top_t − shelf_t. Module drops in from below and is held up against
 // the shelf by adhesive or a clamping backing plate.
-disp_pocket_w = disp_module_w + 2 * disp_cut_tol;   // 31.80
-disp_pocket_h = disp_module_h + 2 * disp_cut_tol;   // 37.52
-disp_pocket_r = disp_module_r + disp_cut_tol;       // 2.35
-disp_pocket_d = top_t - shelf_t;                    // 3.50 with top_t=5, shelf_t=1.5
+disp_pocket_w = disp_module_w + 2 * disp_cut_tol;   // 32.10
+disp_pocket_h = disp_module_h + 2 * disp_cut_tol;   // 37.82
+disp_pocket_r = disp_module_r + disp_cut_tol;       // 2.50
+disp_pocket_d = top_t - shelf_t;                    // 2.0 with top_t=3.5, shelf_t=1.5
 
 // Top window: visible from above, cut through the thin shelf. Asymmetric X/Y
 // offsets from the pocket, blended at the corners by a `shelf_corner_r` fillet
 // via hull-of-circles (see `display_window_2d` below) so the shelf thickness
 // transitions smoothly from shelf_frame_x along the short sides to
 // shelf_frame_y along the long sides with no sharp notches.
-disp_win_w = disp_pocket_w - 2 * shelf_frame_x;     // 29.80
-disp_win_h = disp_pocket_h - 2 * shelf_frame_y;     // 34.32
+disp_win_w = disp_pocket_w - 2 * shelf_frame_x;     // 30.10
+disp_win_h = disp_pocket_h - 2 * shelf_frame_y;     // 34.62
 
 // Assertions — stricter than before so the shelf has ±0.2 mm fab-slop margin
 // on the active-area clearance in both axes. The active area sits at
 // `disp_cut_tol + (module − active)/2` in pocket-local coordinates, so that
 // is the position the shelf inner edge must not reach even after fab slop.
 FAB_SLOP = 0.2;
-active_edge_x = disp_cut_tol + (disp_module_w - disp_active_w) / 2;   // 1.35
-active_edge_y = disp_cut_tol + (disp_module_h - disp_active_h) / 2;   // 2.41
+active_edge_x = disp_cut_tol + (disp_module_w - disp_active_w) / 2;   // 1.50
+active_edge_y = disp_cut_tol + (disp_module_h - disp_active_h) / 2;   // 2.56
 assert(shelf_frame_x + FAB_SLOP <= active_edge_x,
        "shelf_frame_x too large: under ±0.2 mm fab slop the shelf would bite active pixels in X");
 assert(shelf_frame_y + FAB_SLOP <= active_edge_y,
@@ -2033,13 +2033,13 @@ slot_top_above_plate = plate_recess + slot_open_margin;   // 2.0 + 1.5 = 3.5 mm
 slot_bot_below_plate = gasket_compressed
                      + (tab_len + slot_tol) * tan(tilt_angle) / 2
                      + FAB_SLOP + 0.05;
-                                                          // 1.5 + 0.884 + 0.2 + 0.05 = 2.634 mm
+                                                          // 1.5 + 1.072 + 0.2 + 0.05 = 2.822 mm
 slot_height          = plate_t + slot_top_above_plate + slot_bot_below_plate;
-                                                          // 1.6 + 3.5 + 2.634 = 7.734 mm
+                                                          // 1.6 + 3.5 + 2.822 = 7.922 mm
 // Slot center, relative to plate midplane. Positive = slot is offset upward.
 // (slot_top + slot_bot)/2 = plate_midplane + (slot_top_above_plate − slot_bot_below_plate)/2
 slot_center_offset   = (slot_top_above_plate - slot_bot_below_plate) / 2;
-                                                          // (3.5 − 2.634)/2 = +0.433 mm
+                                                          // (3.5 − 2.822)/2 = +0.339 mm
 
 module gasket_slots() {
     // ── Back wall slots (3) ──────────────────────────────────────────────

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -517,23 +517,23 @@ function magnet_positions() = [
 
 // ─── Screw + nut pockets (optional, ENABLE_SCREW_INSERTS) ───────────────────
 // M1.6 hex nuts glued into hex-shaped pockets in the overlay underside;
-// M1.6 captive bolts drop into the tray wall top and snap into the nuts
-// when the overlay is placed. The bolt is a captive pin — head catches on
-// a step in the tray wall, shaft protrudes above the wall top into the nut.
-// No tightening required (gaskets provide compression, bolts prevent lift).
+// M1.6 bolts thread up from the tray underside through the wall columns
+// and into the overlay nuts. Tightened from below (flip case over).
 //
-// Hole arrangement (from wall top surface, going DOWN into the tray wall):
-//   1. Clearance hole: screw_clear_d × screw_clear_depth  (shaft passes here)
-//   2. Counterbore:    screw_head_d  × screw_head_depth   (head sits here)
-// Total depth 3.2 mm — within JLC3DP SLA max (6 mm for 2 mm dia holes).
+// The through-hole is built from two printed segments that meet in the
+// middle of the wall — no post-print drilling required:
+//   1. Pocket (screw_pocket_d, from tray bottom/chamfer face going UP):
+//      wide enough for the bolt head, deep enough to reach the clearance.
+//   2. Clearance (screw_clear_d, from wall top going DOWN):
+//      narrow shaft hole, 6 mm deep (JLC max for 2 mm dia).
+// Both segments stay within JLC3DP SLA depth limits (max 3× diameter)
+// and overlap by 0.5 mm so the printed hole is continuous.
 //
 // SLA resin warps under heat, so heat-set inserts are not usable here.
 // Glued hex nuts are the correct fastener for this process.
 //
 // Hardware: 4× M1.6 hex nut DIN 934 (3.2 mm AF, 1.3 mm thick),
-//           4× M1.6 × 3 mm SHCS (same length front and back).
-// Bolt stack-up: 1.5 mm shaft in clearance + 1.5 mm tip above wall top
-// (full 1.3 mm nut engagement + 0.2 mm spare).
+//           4× M1.6 × 8 mm SHCS (same length front and back).
 screw_nut_af       = 3.4;    // hex pocket across-flats (3.2 mm M1.6 nut +
                              // 0.2 mm SLA dimensional tolerance). Oriented
                              // with flats parallel to wall faces so AF
@@ -541,12 +541,15 @@ screw_nut_af       = 3.4;    // hex pocket across-flats (3.2 mm M1.6 nut +
 screw_nut_depth    = 1.5;    // hex pocket depth (1.3 mm nut + 0.2 mm glue
                              // headroom). Leaves top_t − 1.5 = 2.0 mm of
                              // overlay skin above the pocket.
-screw_clear_d      = 2.0;    // M1.6 clearance hole in tray wall top
-screw_clear_depth  = 1.5;    // clearance hole depth (bolt shaft length in hole)
-screw_head_d       = 3.3;    // counterbore diameter (M1.6 SHCS head OD
-                             // 3.0 mm + 0.3 mm clearance)
-screw_head_depth   = 1.7;    // counterbore depth (1.6 mm head + 0.1 mm recess
-                             // so the head sits fully below the wall top)
+screw_clear_d      = 2.0;    // M1.6 clearance hole from wall top going down
+screw_clear_depth  = 6.0;    // clearance depth from wall top (JLC max for 2 mm)
+screw_pocket_d     = 5.0;    // bolt head pocket from tray bottom going up.
+                             // Wider than screw_head (3.0 mm) so the head
+                             // catches on the step to the narrower clearance.
+                             // 5 mm allows JLC-max depth of 15 mm (3× dia),
+                             // enough to reach the clearance at both front
+                             // (9.9 mm, ratio 2.0×) and back (14.4 mm,
+                             // ratio 2.9×) wall heights.
 screw_inset        = 13;     // corner inset (same geometry as magnet_inset)
 screw_wall_offset  = 3.0;    // screw center distance from outer case face.
                              // Shifted inward from wall_t/2 = 2.4 to improve
@@ -1039,16 +1042,21 @@ screw_nut_ac = screw_nut_af / cos(30);
 // nearest edge of the nut pocket. Uses screw_wall_offset as the center.
 assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_nut_af / 2) >= 1.0,
        "hex nut pocket outer cheek < 1.0 mm in overlay wall");
-// Tray wall cheek around the counterbore (outer side).
-assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_head_d / 2) >= 1.0,
-       "screw counterbore outer cheek < 1.0 mm in tray wall");
+// Tray wall cheek around the bolt pocket (outer side).
+assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_pocket_d / 2) >= 0.3,
+       "screw pocket outer cheek < 0.3 mm in tray wall");
 // Hex pocket must not breach the overlay top surface.
 assert(!ENABLE_SCREW_INSERTS || screw_nut_depth <= top_t - 1.0,
        "hex nut pocket depth leaves < 1.0 mm of overlay skin above the pocket");
-// Total hole depth (clearance + counterbore) must stay within JLC3DP SLA
-// max hole depth for the clearance diameter (6 mm for 2 mm dia holes).
-assert(!ENABLE_SCREW_INSERTS || (screw_clear_depth + screw_head_depth) <= 6.0,
-       "screw hole total depth exceeds JLC3DP SLA max (6 mm for 2 mm dia)");
+// Clearance hole depth must stay within JLC3DP SLA max (3× diameter).
+assert(!ENABLE_SCREW_INSERTS || screw_clear_depth <= screw_clear_d * 3,
+       "clearance hole depth exceeds JLC3DP SLA max (3× diameter)");
+// Bolt pocket depth at each position must stay within JLC3DP SLA max.
+// The pocket depth varies: front starts at z=0, back starts above the
+// chamfer. Checked per-position in the geometry module; the parameter
+// assertion here guards the worst case (full wall height with no chamfer).
+assert(!ENABLE_SCREW_INSERTS || screw_pocket_d * 3 >= 10,
+       "screw pocket diameter too small — max printable depth (3× dia) may not reach clearance");
 // Every screw position must have adequate outer cheek (pocket does not
 // breach the case outer face) and must sit on a wall (not floating in the
 // cavity). The pocket intentionally protrudes slightly into the cavity on
@@ -1056,7 +1064,7 @@ assert(!ENABLE_SCREW_INSERTS || (screw_clear_depth + screw_head_depth) <= 6.0,
 // the pocket inward for better outer cheek).
 assert(!ENABLE_SCREW_INSERTS ||
        len([for (p = screw_positions())
-            let (r = max(screw_nut_ac, screw_head_d) / 2)
+            let (r = max(screw_nut_ac, screw_pocket_d) / 2)
             if (p[0] - r < 0.3 ||
                 p[0] + r > outer_w - 0.3 ||
                 p[1] - r < 0.3 ||
@@ -1073,7 +1081,7 @@ assert(!ENABLE_SCREW_INSERTS ||
 // Screw positions must not collide with any gasket slot footprint.
 assert(!ENABLE_SCREW_INSERTS ||
        len([for (p = screw_positions())
-            let (r = max(screw_nut_ac, screw_head_d) / 2)
+            let (r = max(screw_nut_ac, screw_pocket_d) / 2)
             for (bx = back_tab_cx)
             let (sx1 = p2c_x(bx) - (tab_len + slot_tol)/2 - r,
                  sx2 = p2c_x(bx) + (tab_len + slot_tol)/2 + r)
@@ -1082,7 +1090,7 @@ assert(!ENABLE_SCREW_INSERTS ||
        "a back-wall screw position overlaps a back gasket slot");
 assert(!ENABLE_SCREW_INSERTS ||
        len([for (p = screw_positions())
-            let (r = max(screw_nut_ac, screw_head_d) / 2)
+            let (r = max(screw_nut_ac, screw_pocket_d) / 2)
             for (fx = front_tab_cx)
             let (sx1 = p2c_x(fx) - (tab_len + slot_tol)/2 - r,
                  sx2 = p2c_x(fx) + (tab_len + slot_tol)/2 + r)
@@ -1100,7 +1108,7 @@ assert(!ENABLE_SCREW_INSERTS ||
 // ─── Screw × tongue auto-notching invariants ───────────────────────────────
 // Same pattern as magnet × tongue checks. The notch must clear the hex
 // across-corners extent (vertices extend further than the counterbore).
-screw_notch_extent = max(screw_nut_ac, screw_head_d);
+screw_notch_extent = max(screw_nut_ac, screw_pocket_d);
 // Every screw position must be adjacent to a wall for the notch
 // classification to work.
 assert(!(ENABLE_SCREW_INSERTS && ENABLE_OVERLAY_RABBET) ||
@@ -1654,37 +1662,38 @@ module overlay_magnet_pockets() {
 }
 
 // ─── Screw + nut geometry (optional, ENABLE_SCREW_INSERTS) ─────────────────
-// Captive bolt in the tray wall top. The bolt is inserted tip-first from
-// the wall top surface. The shaft passes through a narrow clearance hole,
-// then the head catches on the wider counterbore step below. The shaft
-// protrudes above the wall top into the overlay nut pocket.
-//
-// Tray (from wall top surface, going DOWN):
-//   1. Clearance: screw_clear_d × screw_clear_depth
-//   2. Counterbore: screw_head_d × screw_head_depth
-//   Total: 3.2 mm — within JLC3DP SLA max (6 mm for 2 mm dia).
+// Through-bolt from tray bottom to overlay nut. Two printed segments meet
+// in the middle of the wall:
+//   1. Pocket (wide, from bottom/chamfer going UP) — bolt head sits here
+//   2. Clearance (narrow, from wall top going DOWN) — bolt shaft passes here
+// The step between them catches the bolt head.
 //
 // Overlay: hex-shaped blind pocket (screw_nut_af × screw_nut_depth) cut
 //   from the underside, with tilt compensation as per magnet pockets.
 
-// Tilt-drift values for the tray clearance hole (exits through tilted
-// wall top) and the overlay nut pocket.
+// Tilt-drift values.
 screw_clear_tilt_drift = screw_clear_d * tan(tilt_angle);
 screw_clear_cyl_h      = screw_clear_depth + screw_clear_tilt_drift + 0.2;
-screw_head_cyl_h       = screw_head_depth + screw_clear_tilt_drift + 0.2;
 screw_nut_tilt_drift   = screw_nut_ac * tan(tilt_angle);
 screw_nut_cyl_h        = screw_nut_depth + screw_nut_tilt_drift + 0.2;
 
 module tray_screw_holes() {
     for (p = screw_positions()) {
-        // Clearance hole at the wall top. Tilt-compensated: anchor to the
-        // uphill edge so the hole exits cleanly through the tilted surface.
+        // Clearance hole from wall top going DOWN. Tilt-compensated at the
+        // wall top surface (anchor to uphill edge).
         z_top_hi = top_z(p[1] + screw_clear_d/2) - top_t + 0.1;
         translate([p[0], p[1], z_top_hi - screw_clear_cyl_h])
             cylinder(d = screw_clear_d, h = screw_clear_cyl_h);
-        // Counterbore below the clearance hole. Same tilt anchor.
-        translate([p[0], p[1], z_top_hi - screw_clear_cyl_h - screw_head_cyl_h + 0.01])
-            cylinder(d = screw_head_d, h = screw_head_cyl_h);
+
+        // Bolt head pocket from tray bottom going UP. Extends from below
+        // the tray bottom (z = -0.1) to 0.5 mm above the clearance hole
+        // bottom, so the two segments overlap and form a continuous hole.
+        // At back positions where the chamfer removes the bottom material,
+        // the pocket effectively starts at the chamfer surface — the lower
+        // part of the cylinder cuts through air.
+        pocket_top = z_top_hi - screw_clear_cyl_h + 0.5;
+        translate([p[0], p[1], -0.1])
+            cylinder(d = screw_pocket_d, h = pocket_top + 0.1);
     }
 }
 

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -547,8 +547,8 @@ screw_nut_depth    = 2.5;    // hex pocket depth. Deeper than the 1.3 mm nut
                              // overlay skin above the pocket (structural,
                              // not cosmetic — the pocket is over the wall).
 screw_clear_d      = 2.0;    // M1.6 clearance hole through tray wall column
-screw_head_d       = 3.5;    // counterbore diameter on tray underside (M1.6
-                             // SHCS head OD 3.0 mm + 0.5 mm clearance)
+screw_head_d       = 3.3;    // counterbore diameter on tray underside (M1.6
+                             // SHCS head OD 3.0 mm + 0.3 mm clearance)
 screw_head_depth   = 1.5;    // counterbore depth into tray bottom
 screw_inset        = 13;     // corner inset (same geometry as magnet_inset)
 
@@ -1661,11 +1661,27 @@ module overlay_magnet_pockets() {
 screw_nut_tilt_drift = screw_nut_ac * tan(tilt_angle);
 screw_nut_cyl_h      = screw_nut_depth + screw_nut_tilt_drift + 0.2;
 
+// Local boss at each back screw position to fill the chamfer_back_bottom
+// zone and provide a flat landing for the counterbore. Without this, the
+// 10 mm back chamfer removes all material at z=0 where the back screws sit.
+// Boss diameter = screw_head_d + 2 mm cheek; height = chamfer surface Z at
+// that Y position. Front screws don't need bosses (no bottom chamfer there).
+screw_boss_d = screw_head_d + 2 * 1.0;  // 1.0 mm cheek around the counterbore
+module tray_screw_bosses() {
+    cb = chamfer_back_bottom;
+    for (p = screw_positions()) {
+        // chamfer Z at this Y: cb - distance from back outer face (in tray-ext coords)
+        chamfer_z = cb - (outer_d + tray_ext - p[1]);
+        if (chamfer_z > 0) {
+            translate([p[0], p[1], 0])
+                cylinder(d = screw_boss_d, h = chamfer_z);
+        }
+    }
+}
+
 module tray_screw_holes() {
     for (p = screw_positions()) {
         // Counterbore on tray underside: flat at z=0 (no tilt here).
-        // Extends upward from z = -0.1 (slight overshoot below bottom face)
-        // by screw_head_depth + 0.1.
         translate([p[0], p[1], -0.1])
             cylinder(d = screw_head_d, h = screw_head_depth + 0.1);
         // Clearance hole: from top of counterbore up through the entire
@@ -1770,6 +1786,10 @@ module case_tray() {
         // wall top. Unioned AFTER the cavity/slot/magnet cuts so its
         // geometry is preserved in full.
         if (ENABLE_OVERLAY_RABBET) tray_tongue_3d();
+
+        // Optional: local bosses that fill the back chamfer at the back
+        // screw positions, providing a flat counterbore landing.
+        if (ENABLE_SCREW_INSERTS && ENABLE_CHAMFERS) tray_screw_bosses();
     }
 }
 

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -72,11 +72,10 @@ ENABLE_MAGNET_POCKETS = true;    // cut blind magnet pockets in the tray wall
                                  // magnetically (serviceable — overlay lifts
                                  // off for PCB access). Counts on N52 disc
                                  // magnets — see magnet_* params below.
-ENABLE_SCREW_INSERTS  = false;   // M1.6 hex nuts (glued) in hex pockets in the
-                                 // overlay underside + captive bolts threading
-                                 // up from inside the tray. 4 corner positions.
-                                 // Nothing visible externally. Mutually
-                                 // exclusive with ENABLE_MAGNET_POCKETS.
+ENABLE_SCREW_INSERTS  = false;   // M1.4 hex nuts (glued) in hex pockets in the
+                                 // overlay underside + bolts threading up from
+                                 // the tray underside. 4 corner positions.
+                                 // Mutually exclusive with ENABLE_MAGNET_POCKETS.
 
 // ─── Decorative trims (3D-print-only) ───────────────────────────────────────
 // Cosmetic embellishments with no mechanical role. Only practical on printed
@@ -516,44 +515,34 @@ function magnet_positions() = [
 ];
 
 // ─── Screw + nut pockets (optional, ENABLE_SCREW_INSERTS) ───────────────────
-// M1.6 hex nuts glued into hex-shaped pockets in the overlay underside;
-// M1.6 bolts thread up from the tray underside through the wall columns
+// M1.4 hex nuts glued into hex pockets in the overlay underside;
+// M1.4 bolts thread up from the tray underside through the wall columns
 // and into the overlay nuts. Tightened from below (flip case over).
 //
 // The through-hole is a 3-segment stepped bore — each segment stays
-// within JLC3DP SLA's 3× diameter depth limit, and all fit inside the
-// 4.8 mm wall (max segment dia 3.3 mm). No post-print drilling:
-//   1. Pocket  (3.3 mm, from tray bottom/chamfer UP): bolt head sits here
+// within JLC3DP SLA's 3× diameter depth limit:
+//   1. Pocket  (3.0 mm, from tray bottom UP): bolt head sits here
 //   2. Mid     (2.5 mm, intermediate): extends the printable depth
 //   3. Clear   (2.0 mm, from wall top DOWN 6 mm): shaft exits here
-// The bolt head catches on the pocket→mid step. The shaft passes through
-// the mid and clearance segments.
+// The bolt head catches on the pocket→mid step. At back positions the
+// lower portion of the pocket extends into the chamfer void (deboss).
 //
-// SLA resin warps under heat, so heat-set inserts are not usable here.
-// Glued hex nuts are the correct fastener for this process.
-//
-// Hardware: 4× M1.6 hex nut DIN 934 (3.2 mm AF, 1.3 mm thick),
-//           4× M1.6 × 12 mm SHCS (same length front and back).
-screw_nut_af       = 3.4;    // hex pocket across-flats (3.2 mm M1.6 nut +
-                             // 0.2 mm SLA dimensional tolerance). Oriented
-                             // with flats parallel to wall faces so AF
-                             // constrains the wall-thickness cheek.
-screw_nut_depth    = 2.5;    // hex pocket depth. Deeper than the 1.3 mm nut
-                             // to accommodate bolt tip variance between
-                             // front (1.3 mm protrusion) and tolerance.
-screw_pocket_d     = 3.3;    // bottom segment — catches bolt head (3.0 mm
-                             // SHCS head + 0.3 mm clearance)
-screw_mid_d        = 2.5;    // intermediate segment — extends printable depth
-screw_clear_d      = 2.0;    // top segment — M1.6 clearance from wall top
+// Hardware: 4× M1.4 hex nut DIN 934 (3.0 mm AF, 1.2 mm thick),
+//           4× M1.4 × 12 mm SHCS (2.6 mm head dia, 1.4 mm head height).
+screw_nut_af       = 3.2;    // hex pocket across-flats (3.0 mm M1.4 nut +
+                             // 0.2 mm SLA dimensional tolerance)
+screw_nut_depth    = 2.5;    // hex pocket depth (1.2 mm nut + margin for
+                             // bolt tip and tolerance)
+screw_pocket_d     = 3.0;    // bottom segment — catches bolt head (2.6 mm
+                             // M1.4 SHCS head + 0.4 mm clearance)
+screw_mid_d        = 2.5;    // intermediate segment
+screw_clear_d      = 2.0;    // top segment — M1.4 clearance from wall top
 screw_clear_depth  = 6.0;    // top segment depth (JLC max for 2 mm: 6 mm)
-screw_bolt_length  = 12;     // M1.6 × 12 mm (same at all 4 positions)
+screw_bolt_length  = 12;     // M1.4 × 12 mm (same length all 4 positions)
 screw_inset        = 13;     // corner inset (same geometry as magnet_inset)
-screw_wall_offset  = 3.0;    // screw center distance from outer case face
-screw_reinf        = 0.4;    // reinforcement pad depth on cavity inner face
-                             // (stays within plate_gap = 0.5 mm)
+screw_wall_offset  = wall_t / 2;  // centered in wall — adequate cheek on
+                                  // both sides with M1.4
 
-// Screw positions: 4 corners. The wall-thickness coordinate uses
-// screw_wall_offset instead of wall_t/2 for the cheek improvement.
 function screw_positions() = [
     [screw_inset,                  screw_wall_offset],                // front-left
     [outer_w - screw_inset,        screw_wall_offset],                // front-right
@@ -1028,49 +1017,24 @@ assert(!(ENABLE_MAGNET_POCKETS && ENABLE_OVERLAY_RABBET) ||
        "a magnet notch enters the overlay's rounded outer corner region");
 
 // ─── Screw + nut invariants (only enforced when ENABLE_SCREW_INSERTS) ───────
-// Mutually exclusive with magnets — both drill into the same wall-top real
-// estate, and the positions overlap.
 assert(!(ENABLE_SCREW_INSERTS && ENABLE_MAGNET_POCKETS),
        "ENABLE_SCREW_INSERTS and ENABLE_MAGNET_POCKETS are mutually exclusive");
-// Hex nut across-corners (the bounding circle of the hex pocket).
 screw_nut_ac = screw_nut_af / cos(30);
-// Overlay wall cheek: outer cheek measured from the case outer face to the
-// nearest edge of the nut pocket. Uses screw_wall_offset as the center.
-assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_nut_af / 2) >= 1.0,
-       "hex nut pocket outer cheek < 1.0 mm in overlay wall");
-// Overlay wall cheek: outer cheek measured from case outer face.
-assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_nut_af / 2) >= 1.0,
-       "hex nut pocket outer cheek < 1.0 mm in overlay wall");
-// Tray wall cheek around the widest segment (pocket).
-assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_pocket_d / 2) >= 1.0,
-       "screw pocket outer cheek < 1.0 mm in tray wall");
-// All segments must fit inside the wall (no cavity breach from the
-// pocket alone — reinforcement pad handles structural support).
-assert(!ENABLE_SCREW_INSERTS || screw_wall_offset + screw_pocket_d / 2 <= wall_t + 0.5,
-       "screw pocket breaches inner wall face by more than 0.5 mm");
+// Overlay wall cheek around the hex nut pocket.
+assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_nut_af / 2) >= 0.5,
+       "hex nut pocket outer cheek < 0.5 mm in overlay wall");
+assert(!ENABLE_SCREW_INSERTS || (wall_t - screw_wall_offset - screw_nut_af / 2) >= 0.5,
+       "hex nut pocket inner cheek < 0.5 mm in overlay wall");
+// Tray wall cheek around the widest bore segment (pocket).
+assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_pocket_d / 2) >= 0.5,
+       "screw pocket outer cheek < 0.5 mm in tray wall");
 // Hex pocket must not breach the overlay top surface.
 assert(!ENABLE_SCREW_INSERTS || screw_nut_depth <= top_t - 1.0,
-       "hex nut pocket depth leaves < 1.0 mm of overlay skin above the pocket");
-// Each segment depth must stay within JLC3DP SLA max (3× diameter).
+       "hex nut pocket depth leaves < 1.0 mm of overlay skin above");
+// JLC3DP SLA 3× depth rule for the clearance (topmost) segment.
 assert(!ENABLE_SCREW_INSERTS || screw_clear_depth <= screw_clear_d * 3,
        "clearance segment exceeds JLC3DP SLA max (3× diameter)");
-// Reinforcement pad must not foul the plate.
-assert(!ENABLE_SCREW_INSERTS || screw_reinf <= plate_gap - 0.1,
-       "screw reinforcement pad exceeds plate_gap clearance");
-// Every screw position must have adequate outer cheek (pocket does not
-// breach the case outer face) and must sit on a wall (not floating in the
-// cavity). The pocket intentionally protrudes slightly into the cavity on
-// the inner side — this is by design (screw_wall_offset > wall_t/2 shifts
-// the pocket inward for better outer cheek).
-assert(!ENABLE_SCREW_INSERTS ||
-       len([for (p = screw_positions())
-            let (r = max(screw_nut_ac, screw_pocket_d) / 2)
-            if (p[0] - r < 0.3 ||
-                p[0] + r > outer_w - 0.3 ||
-                p[1] - r < 0.3 ||
-                p[1] + r > outer_d - 0.3) 1]) == 0,
-       "a screw position breaches the case outer boundary");
-// Each screw must be adjacent to a wall (not floating in the cavity center).
+// Positions must sit on walls and clear gasket slots / USB cutout.
 assert(!ENABLE_SCREW_INSERTS ||
        len([for (p = screw_positions())
             if (!(p[1] <= wall_t + 1 ||
@@ -1078,7 +1042,6 @@ assert(!ENABLE_SCREW_INSERTS ||
                   p[0] <= wall_t + 1 ||
                   p[0] >= outer_w - wall_t - 1)) 1]) == 0,
        "a screw position is not adjacent to any wall");
-// Screw positions must not collide with any gasket slot footprint.
 assert(!ENABLE_SCREW_INSERTS ||
        len([for (p = screw_positions())
             let (r = max(screw_nut_ac, screw_pocket_d) / 2)
@@ -1097,20 +1060,15 @@ assert(!ENABLE_SCREW_INSERTS ||
             if (p[0] >= sx1 && p[0] <= sx2 &&
                 p[1] <= wall_t + r) 1]) == 0,
        "a front-wall screw position overlaps a front gasket slot");
-// Screw positions must keep >= 2 mm cheek to USB cutout.
 assert(!ENABLE_SCREW_INSERTS ||
        len([for (p = screw_positions())
-            let (r = max(screw_nut_ac, screw_head_d) / 2,
+            let (r = max(screw_nut_ac, screw_pocket_d) / 2,
                  cheek = abs(p[0] - p2c_x(usb_plate_x)) - usb_cut_w/2 - r)
             if (p[1] >= outer_d - wall_t - r && cheek < 2.0) 1]) == 0,
        "a back-wall screw position leaves < 2 mm cheek to the USB cutout");
 
 // ─── Screw × tongue auto-notching invariants ───────────────────────────────
-// Same pattern as magnet × tongue checks. The notch must clear the hex
-// across-corners extent (vertices extend further than the counterbore).
 screw_notch_extent = max(screw_nut_ac, screw_pocket_d);
-// Every screw position must be adjacent to a wall for the notch
-// classification to work.
 assert(!(ENABLE_SCREW_INSERTS && ENABLE_OVERLAY_RABBET) ||
        len([for (p = screw_positions())
             if (!(p[1] <= wall_t ||
@@ -1662,12 +1620,11 @@ module overlay_magnet_pockets() {
 }
 
 // ─── Screw + nut geometry (optional, ENABLE_SCREW_INSERTS) ─────────────────
-// 3-segment stepped through-bore from tray bottom to wall top. Each
-// segment stays within JLC3DP SLA's 3× depth limit. The bolt head
-// catches on the pocket→mid step; the shaft passes through mid+clear.
-//
-// Overlay: hex-shaped blind pocket (screw_nut_af × screw_nut_depth) cut
-//   from the underside, with tilt compensation as per magnet pockets.
+// Tray:  3-segment stepped through-bore from tray bottom to wall top.
+//        Each segment stays within JLC3DP SLA's 3× depth limit. The bolt
+//        head catches on the pocket→mid step; the shaft passes through
+//        mid+clear and into the overlay nut.
+// Overlay: hex nut pocket on the underside, tilt-compensated.
 
 // Tilt-drift values (wall top surface is tilted).
 screw_clear_tilt_drift = screw_clear_d * tan(tilt_angle);
@@ -1685,7 +1642,7 @@ module tray_screw_holes() {
 
         // Head catch point: where the pocket→mid step is.
         wall_top_center = top_z(p[1]) - top_t;
-        pocket_top = wall_top_center + 1.3 - screw_bolt_length;
+        pocket_top = wall_top_center + 1.2 - screw_bolt_length;
 
         // Mid segment: from pocket_top to clearance bottom + overlap.
         mid_top = clear_bot + 0.5;
@@ -1697,25 +1654,6 @@ module tray_screw_holes() {
         // void — this is intentional (deboss, not protrusion).
         translate([p[0], p[1], -0.1])
             cylinder(d = screw_pocket_d, h = pocket_top + 0.1);
-    }
-}
-
-// Reinforcement pads: local wall thickening on the tray cavity inner
-// face at each screw position. Adds screw_reinf mm of material into
-// the cavity (within plate_gap clearance), improving the structural
-// support around the thin inner cheek of the screw bore.
-module tray_screw_reinforcement() {
-    for (p = screw_positions()) {
-        wall_top_center = top_z(p[1]) - top_t;
-        pad_w = screw_pocket_d + 2;
-        on_front = p[1] < outer_d / 2;
-        if (on_front) {
-            translate([p[0] - pad_w/2, wall_t, bottom_t])
-                cube([pad_w, screw_reinf, wall_top_center - bottom_t]);
-        } else {
-            translate([p[0] - pad_w/2, outer_d - wall_t - screw_reinf, bottom_t])
-                cube([pad_w, screw_reinf, wall_top_center - bottom_t]);
-        }
     }
 }
 
@@ -1800,7 +1738,7 @@ module case_tray() {
             // Optional: magnet pockets sunk into the wall tops.
             if (ENABLE_MAGNET_POCKETS) tray_magnet_pockets();
 
-            // Optional: screw clearance holes + counterbores in the wall tops.
+            // Optional: screw through-bore in the wall columns.
             if (ENABLE_SCREW_INSERTS) tray_screw_holes();
         }
 
@@ -1808,9 +1746,6 @@ module case_tray() {
         // wall top. Unioned AFTER the cavity/slot/magnet cuts so its
         // geometry is preserved in full.
         if (ENABLE_OVERLAY_RABBET) tray_tongue_3d();
-
-        // Reinforcement pads on the cavity inner face at screw positions.
-        if (ENABLE_SCREW_INSERTS) tray_screw_reinforcement();
     }
 }
 
@@ -1844,8 +1779,7 @@ module case_overlay() {
         // the tray pockets across the seam.
         if (ENABLE_MAGNET_POCKETS) overlay_magnet_pockets();
 
-        // Optional: hex nut pockets in the overlay underside, matching
-        // the tray screw holes.
+        // Optional: hex nut pockets in the overlay underside.
         if (ENABLE_SCREW_INSERTS) overlay_nut_pockets();
 
         // Optional: recess cut into the overlay underside that accepts
@@ -2517,7 +2451,7 @@ module case_overlay_chamfered() {
         // Magnet pockets
         if (ENABLE_MAGNET_POCKETS) overlay_magnet_pockets();
 
-        // Screw nut pockets
+        // Hex nut pockets in overlay underside
         if (ENABLE_SCREW_INSERTS) overlay_nut_pockets();
 
         // Rabbet recess

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -517,47 +517,49 @@ function magnet_positions() = [
 
 // ─── Screw + nut pockets (optional, ENABLE_SCREW_INSERTS) ───────────────────
 // M1.6 hex nuts glued into hex-shaped pockets in the overlay underside;
-// M1.6 bolts thread upward from the tray underside (desk-facing bottom)
-// through clearance holes in the wall columns and into the overlay nuts.
-// The bolt heads sit in counterbores recessed into the tray bottom, hidden
-// against the desk. The hex pocket prevents the nut from spinning during
-// tightening; CA glue locks it permanently. 4 corners only — positive
-// mechanical engagement doesn't need mid-wall reinforcement to resist bow.
+// M1.6 captive bolts drop into the tray wall top and snap into the nuts
+// when the overlay is placed. The bolt is a captive pin — head catches on
+// a step in the tray wall, shaft protrudes above the wall top into the nut.
+// No tightening required (gaskets provide compression, bolts prevent lift).
+//
+// Hole arrangement (from wall top surface, going DOWN into the tray wall):
+//   1. Clearance hole: screw_clear_d × screw_clear_depth  (shaft passes here)
+//   2. Counterbore:    screw_head_d  × screw_head_depth   (head sits here)
+// Total depth 3.2 mm — within JLC3DP SLA max (6 mm for 2 mm dia holes).
 //
 // SLA resin warps under heat, so heat-set inserts are not usable here.
 // Glued hex nuts are the correct fastener for this process.
 //
-// Hardware: M1.6 hex nut DIN 934 (3.2 mm AF, 1.3 mm thick),
-//           M1.6 × 16 mm SHCS for front corners,
-//           M1.6 × 25 mm SHCS for back corners.
-// The 6° tilt makes the front wall ~15 mm and back wall ~27 mm tall, so
-// front and back bolts are different lengths. The nut pocket is deepened
-// to 2.5 mm (1.0 mm overlay skin) to widen the bolt-length window enough
-// for standard sizes to fit:
-//   Front: window [13.85, 16.35] → M1.6 × 16 (0.35 mm ceiling clearance)
-//   Back:  window [25.00, 27.50] → M1.6 × 25 (2.50 mm ceiling clearance)
+// Hardware: 4× M1.6 hex nut DIN 934 (3.2 mm AF, 1.3 mm thick),
+//           4× M1.6 × 3 mm SHCS (same length front and back).
+// Bolt stack-up: 1.5 mm shaft in clearance + 1.5 mm tip above wall top
+// (full 1.3 mm nut engagement + 0.2 mm spare).
 screw_nut_af       = 3.4;    // hex pocket across-flats (3.2 mm M1.6 nut +
                              // 0.2 mm SLA dimensional tolerance). Oriented
                              // with flats parallel to wall faces so AF
                              // constrains the wall-thickness cheek.
-screw_nut_depth    = 2.5;    // hex pocket depth. Deeper than the 1.3 mm nut
-                             // to widen the bolt-length tolerance window for
-                             // standard bolt sizes entering from the tray
-                             // underside. Leaves top_t − 2.5 = 1.0 mm of
-                             // overlay skin above the pocket (structural,
-                             // not cosmetic — the pocket is over the wall).
-screw_clear_d      = 2.0;    // M1.6 clearance hole through tray wall column
-screw_head_d       = 3.3;    // counterbore diameter on tray underside (M1.6
-                             // SHCS head OD 3.0 mm + 0.3 mm clearance)
-screw_head_depth   = 1.5;    // counterbore depth into tray bottom
+screw_nut_depth    = 1.5;    // hex pocket depth (1.3 mm nut + 0.2 mm glue
+                             // headroom). Leaves top_t − 1.5 = 2.0 mm of
+                             // overlay skin above the pocket.
+screw_clear_d      = 2.0;    // M1.6 clearance hole in tray wall top
+screw_clear_depth  = 1.5;    // clearance hole depth (bolt shaft length in hole)
+screw_head_d       = 3.3;    // counterbore diameter (M1.6 SHCS head OD
+                             // 3.0 mm + 0.3 mm clearance)
+screw_head_depth   = 1.7;    // counterbore depth (1.6 mm head + 0.1 mm recess
+                             // so the head sits fully below the wall top)
 screw_inset        = 13;     // corner inset (same geometry as magnet_inset)
+screw_wall_offset  = 3.0;    // screw center distance from outer case face.
+                             // Shifted inward from wall_t/2 = 2.4 to improve
+                             // the overlay nut outer cheek from 0.7 → 1.3 mm
+                             // (closer to JLC3DP's 1.5 mm fastener rule).
 
-// Screw positions: 4 corners, same layout function pattern as magnet_positions.
+// Screw positions: 4 corners. The wall-thickness coordinate uses
+// screw_wall_offset instead of wall_t/2 for the cheek improvement.
 function screw_positions() = [
-    [screw_inset,                  wall_t / 2],              // front-left
-    [outer_w - screw_inset,        wall_t / 2],              // front-right
-    [screw_inset,                  outer_d - wall_t / 2],    // back-left
-    [outer_w - screw_inset,        outer_d - wall_t / 2],    // back-right
+    [screw_inset,                  screw_wall_offset],                // front-left
+    [outer_w - screw_inset,        screw_wall_offset],                // front-right
+    [screw_inset,                  outer_d - screw_wall_offset],      // back-left
+    [outer_w - screw_inset,        outer_d - screw_wall_offset],      // back-right
 ];
 
 // =============================================================================
@@ -1033,35 +1035,41 @@ assert(!(ENABLE_SCREW_INSERTS && ENABLE_MAGNET_POCKETS),
        "ENABLE_SCREW_INSERTS and ENABLE_MAGNET_POCKETS are mutually exclusive");
 // Hex nut across-corners (the bounding circle of the hex pocket).
 screw_nut_ac = screw_nut_af / cos(30);
-// Overlay wall cheek: hex pocket AF constrains wall-thickness direction.
-// Same 0.6 mm floor as magnet cheek (blind pocket in a solid body, not a
-// freestanding snap feature).
-assert(!ENABLE_SCREW_INSERTS || (wall_t - screw_nut_af) / 2 >= 0.6,
-       "hex nut pocket leaves < 0.6 mm cheek in overlay wall");
-// Tray wall cheek around the counterbore.
-assert(!ENABLE_SCREW_INSERTS || (tray_wall_t - screw_head_d) / 2 >= 0.8,
-       "screw counterbore leaves < 0.8 mm cheek in tray wall");
+// Overlay wall cheek: outer cheek measured from the case outer face to the
+// nearest edge of the nut pocket. Uses screw_wall_offset as the center.
+assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_nut_af / 2) >= 1.0,
+       "hex nut pocket outer cheek < 1.0 mm in overlay wall");
+// Tray wall cheek around the counterbore (outer side).
+assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_head_d / 2) >= 1.0,
+       "screw counterbore outer cheek < 1.0 mm in tray wall");
 // Hex pocket must not breach the overlay top surface.
 assert(!ENABLE_SCREW_INSERTS || screw_nut_depth <= top_t - 1.0,
        "hex nut pocket depth leaves < 1.0 mm of overlay skin above the pocket");
-// Counterbore on the tray underside must not breach the cavity floor.
-assert(!ENABLE_SCREW_INSERTS || screw_head_depth <= bottom_t - 1.0,
-       "screw counterbore depth exceeds bottom_t with < 1.0 mm floor remaining");
-// Every screw position must sit entirely inside the wall ring. Use the
-// hex across-corners as the bounding radius (conservative — the hex
-// vertices extend further than the flats).
+// Total hole depth (clearance + counterbore) must stay within JLC3DP SLA
+// max hole depth for the clearance diameter (6 mm for 2 mm dia holes).
+assert(!ENABLE_SCREW_INSERTS || (screw_clear_depth + screw_head_depth) <= 6.0,
+       "screw hole total depth exceeds JLC3DP SLA max (6 mm for 2 mm dia)");
+// Every screw position must have adequate outer cheek (pocket does not
+// breach the case outer face) and must sit on a wall (not floating in the
+// cavity). The pocket intentionally protrudes slightly into the cavity on
+// the inner side — this is by design (screw_wall_offset > wall_t/2 shifts
+// the pocket inward for better outer cheek).
 assert(!ENABLE_SCREW_INSERTS ||
        len([for (p = screw_positions())
             let (r = max(screw_nut_ac, screw_head_d) / 2)
             if (p[0] - r < 0.3 ||
                 p[0] + r > outer_w - 0.3 ||
                 p[1] - r < 0.3 ||
-                p[1] + r > outer_d - 0.3 ||
-                (p[0] + r > wall_t - 0.3 &&
-                 p[0] - r < outer_w - wall_t + 0.3 &&
-                 p[1] + r > wall_t - 0.3 &&
-                 p[1] - r < outer_d - wall_t + 0.3)) 1]) == 0,
-       "a screw position does not sit fully inside the wall ring material");
+                p[1] + r > outer_d - 0.3) 1]) == 0,
+       "a screw position breaches the case outer boundary");
+// Each screw must be adjacent to a wall (not floating in the cavity center).
+assert(!ENABLE_SCREW_INSERTS ||
+       len([for (p = screw_positions())
+            if (!(p[1] <= wall_t + 1 ||
+                  p[1] >= outer_d - wall_t - 1 ||
+                  p[0] <= wall_t + 1 ||
+                  p[0] >= outer_w - wall_t - 1)) 1]) == 0,
+       "a screw position is not adjacent to any wall");
 // Screw positions must not collide with any gasket slot footprint.
 assert(!ENABLE_SCREW_INSERTS ||
        len([for (p = screw_positions())
@@ -1646,61 +1654,44 @@ module overlay_magnet_pockets() {
 }
 
 // ─── Screw + nut geometry (optional, ENABLE_SCREW_INSERTS) ─────────────────
-// Bolt enters from the tray underside (z=0), passes up through the wall
-// column, exits the wall top, and threads into a hex nut glued in the
-// overlay underside. Assembly: flip case upside-down, insert bolts, tighten.
+// Captive bolt in the tray wall top. The bolt is inserted tip-first from
+// the wall top surface. The shaft passes through a narrow clearance hole,
+// then the head catches on the wider counterbore step below. The shaft
+// protrudes above the wall top into the overlay nut pocket.
 //
-// Tray: counterbore (screw_head_d × screw_head_depth) at the tray underside
-//   (flat, no tilt compensation needed), plus a clearance through-hole
-//   (screw_clear_d) from the counterbore top all the way up through the
-//   wall to above the tilted wall top.
+// Tray (from wall top surface, going DOWN):
+//   1. Clearance: screw_clear_d × screw_clear_depth
+//   2. Counterbore: screw_head_d × screw_head_depth
+//   Total: 3.2 mm — within JLC3DP SLA max (6 mm for 2 mm dia).
+//
 // Overlay: hex-shaped blind pocket (screw_nut_af × screw_nut_depth) cut
-//   from the overlay underside, with tilt compensation as per magnet pockets.
+//   from the underside, with tilt compensation as per magnet pockets.
 
-// Tilt-drift values for the overlay nut pocket.
-screw_nut_tilt_drift = screw_nut_ac * tan(tilt_angle);
-screw_nut_cyl_h      = screw_nut_depth + screw_nut_tilt_drift + 0.2;
-
-// Local boss at each back screw position to fill the chamfer_back_bottom
-// zone and provide a flat landing for the counterbore. Without this, the
-// 10 mm back chamfer removes all material at z=0 where the back screws sit.
-// Boss diameter = screw_head_d + 2 mm cheek; height = chamfer surface Z at
-// that Y position. Front screws don't need bosses (no bottom chamfer there).
-screw_boss_d = screw_head_d + 2 * 1.0;  // 1.0 mm cheek around the counterbore
-module tray_screw_bosses() {
-    cb = chamfer_back_bottom;
-    for (p = screw_positions()) {
-        // chamfer Z at this Y: cb - distance from back outer face (in tray-ext coords)
-        chamfer_z = cb - (outer_d + tray_ext - p[1]);
-        if (chamfer_z > 0) {
-            translate([p[0], p[1], 0])
-                cylinder(d = screw_boss_d, h = chamfer_z);
-        }
-    }
-}
+// Tilt-drift values for the tray clearance hole (exits through tilted
+// wall top) and the overlay nut pocket.
+screw_clear_tilt_drift = screw_clear_d * tan(tilt_angle);
+screw_clear_cyl_h      = screw_clear_depth + screw_clear_tilt_drift + 0.2;
+screw_head_cyl_h       = screw_head_depth + screw_clear_tilt_drift + 0.2;
+screw_nut_tilt_drift   = screw_nut_ac * tan(tilt_angle);
+screw_nut_cyl_h        = screw_nut_depth + screw_nut_tilt_drift + 0.2;
 
 module tray_screw_holes() {
     for (p = screw_positions()) {
-        // Counterbore on tray underside: flat at z=0 (no tilt here).
-        translate([p[0], p[1], -0.1])
-            cylinder(d = screw_head_d, h = screw_head_depth + 0.1);
-        // Clearance hole: from top of counterbore up through the entire
-        // wall column to above the tilted wall top. Tilt compensation at
-        // the top: the hole must exit cleanly through the tilted surface,
-        // so extend well past the highest point of the wall top at this Y.
-        z_wall_top_hi = top_z(p[1] + screw_clear_d/2) - top_t + 0.1;
-        translate([p[0], p[1], screw_head_depth - 0.01])
-            cylinder(d = screw_clear_d, h = z_wall_top_hi - screw_head_depth + 0.02);
+        // Clearance hole at the wall top. Tilt-compensated: anchor to the
+        // uphill edge so the hole exits cleanly through the tilted surface.
+        z_top_hi = top_z(p[1] + screw_clear_d/2) - top_t + 0.1;
+        translate([p[0], p[1], z_top_hi - screw_clear_cyl_h])
+            cylinder(d = screw_clear_d, h = screw_clear_cyl_h);
+        // Counterbore below the clearance hole. Same tilt anchor.
+        translate([p[0], p[1], z_top_hi - screw_clear_cyl_h - screw_head_cyl_h + 0.01])
+            cylinder(d = screw_head_d, h = screw_head_cyl_h);
     }
 }
 
 module overlay_nut_pockets() {
     for (p = screw_positions()) {
-        // Hex pocket: bottom at downhill edge − 0.1 mm undershoot, extends
-        // up by nut depth + drift. $fn=6 creates a hex prism; the default
-        // orientation places flats perpendicular to Y (parallel to front/back
-        // wall faces). The `d` parameter sets the circumscribed circle
-        // (across-corners); we derive it from the desired across-flats.
+        // Hex pocket on the overlay underside. Tilt-compensated: bottom at
+        // the downhill edge − 0.1 mm undershoot.
         z_bot_lo = top_z(p[1] - screw_nut_ac/2) - top_t - 0.1;
         translate([p[0], p[1], z_bot_lo])
             cylinder(d = screw_nut_ac, h = screw_nut_cyl_h, $fn = 6);
@@ -1786,10 +1777,6 @@ module case_tray() {
         // wall top. Unioned AFTER the cavity/slot/magnet cuts so its
         // geometry is preserved in full.
         if (ENABLE_OVERLAY_RABBET) tray_tongue_3d();
-
-        // Optional: local bosses that fill the back chamfer at the back
-        // screw positions, providing a flat counterbore landing.
-        if (ENABLE_SCREW_INSERTS && ENABLE_CHAMFERS) tray_screw_bosses();
     }
 }
 

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -520,41 +520,37 @@ function magnet_positions() = [
 // M1.6 bolts thread up from the tray underside through the wall columns
 // and into the overlay nuts. Tightened from below (flip case over).
 //
-// The through-hole is built from two printed segments that meet in the
-// middle of the wall — no post-print drilling required:
-//   1. Pocket (screw_pocket_d, from tray bottom/chamfer face going UP):
-//      wide enough for the bolt head, deep enough to reach the clearance.
-//   2. Clearance (screw_clear_d, from wall top going DOWN):
-//      narrow shaft hole, 6 mm deep (JLC max for 2 mm dia).
-// Both segments stay within JLC3DP SLA depth limits (max 3× diameter)
-// and overlap by 0.5 mm so the printed hole is continuous.
+// The through-hole is a 3-segment stepped bore — each segment stays
+// within JLC3DP SLA's 3× diameter depth limit, and all fit inside the
+// 4.8 mm wall (max segment dia 3.3 mm). No post-print drilling:
+//   1. Pocket  (3.3 mm, from tray bottom/chamfer UP): bolt head sits here
+//   2. Mid     (2.5 mm, intermediate): extends the printable depth
+//   3. Clear   (2.0 mm, from wall top DOWN 6 mm): shaft exits here
+// The bolt head catches on the pocket→mid step. The shaft passes through
+// the mid and clearance segments.
 //
 // SLA resin warps under heat, so heat-set inserts are not usable here.
 // Glued hex nuts are the correct fastener for this process.
 //
 // Hardware: 4× M1.6 hex nut DIN 934 (3.2 mm AF, 1.3 mm thick),
-//           4× M1.6 × 8 mm SHCS (same length front and back).
+//           4× M1.6 × 12 mm SHCS (same length front and back).
 screw_nut_af       = 3.4;    // hex pocket across-flats (3.2 mm M1.6 nut +
                              // 0.2 mm SLA dimensional tolerance). Oriented
                              // with flats parallel to wall faces so AF
                              // constrains the wall-thickness cheek.
-screw_nut_depth    = 1.5;    // hex pocket depth (1.3 mm nut + 0.2 mm glue
-                             // headroom). Leaves top_t − 1.5 = 2.0 mm of
-                             // overlay skin above the pocket.
-screw_clear_d      = 2.0;    // M1.6 clearance hole from wall top going down
-screw_clear_depth  = 6.0;    // clearance depth from wall top (JLC max for 2 mm)
-screw_pocket_d     = 5.0;    // bolt head pocket from tray bottom going up.
-                             // Wider than screw_head (3.0 mm) so the head
-                             // catches on the step to the narrower clearance.
-                             // 5 mm allows JLC-max depth of 15 mm (3× dia),
-                             // enough to reach the clearance at both front
-                             // (9.9 mm, ratio 2.0×) and back (14.4 mm,
-                             // ratio 2.9×) wall heights.
+screw_nut_depth    = 2.5;    // hex pocket depth. Deeper than the 1.3 mm nut
+                             // to accommodate bolt tip variance between
+                             // front (1.3 mm protrusion) and tolerance.
+screw_pocket_d     = 3.3;    // bottom segment — catches bolt head (3.0 mm
+                             // SHCS head + 0.3 mm clearance)
+screw_mid_d        = 2.5;    // intermediate segment — extends printable depth
+screw_clear_d      = 2.0;    // top segment — M1.6 clearance from wall top
+screw_clear_depth  = 6.0;    // top segment depth (JLC max for 2 mm: 6 mm)
+screw_bolt_length  = 12;     // M1.6 × 12 mm (same at all 4 positions)
 screw_inset        = 13;     // corner inset (same geometry as magnet_inset)
-screw_wall_offset  = 3.0;    // screw center distance from outer case face.
-                             // Shifted inward from wall_t/2 = 2.4 to improve
-                             // the overlay nut outer cheek from 0.7 → 1.3 mm
-                             // (closer to JLC3DP's 1.5 mm fastener rule).
+screw_wall_offset  = 3.0;    // screw center distance from outer case face
+screw_reinf        = 0.4;    // reinforcement pad depth on cavity inner face
+                             // (stays within plate_gap = 0.5 mm)
 
 // Screw positions: 4 corners. The wall-thickness coordinate uses
 // screw_wall_offset instead of wall_t/2 for the cheek improvement.
@@ -1042,21 +1038,25 @@ screw_nut_ac = screw_nut_af / cos(30);
 // nearest edge of the nut pocket. Uses screw_wall_offset as the center.
 assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_nut_af / 2) >= 1.0,
        "hex nut pocket outer cheek < 1.0 mm in overlay wall");
-// Tray wall cheek around the bolt pocket (outer side).
-assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_pocket_d / 2) >= 0.3,
-       "screw pocket outer cheek < 0.3 mm in tray wall");
+// Overlay wall cheek: outer cheek measured from case outer face.
+assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_nut_af / 2) >= 1.0,
+       "hex nut pocket outer cheek < 1.0 mm in overlay wall");
+// Tray wall cheek around the widest segment (pocket).
+assert(!ENABLE_SCREW_INSERTS || (screw_wall_offset - screw_pocket_d / 2) >= 1.0,
+       "screw pocket outer cheek < 1.0 mm in tray wall");
+// All segments must fit inside the wall (no cavity breach from the
+// pocket alone — reinforcement pad handles structural support).
+assert(!ENABLE_SCREW_INSERTS || screw_wall_offset + screw_pocket_d / 2 <= wall_t + 0.5,
+       "screw pocket breaches inner wall face by more than 0.5 mm");
 // Hex pocket must not breach the overlay top surface.
 assert(!ENABLE_SCREW_INSERTS || screw_nut_depth <= top_t - 1.0,
        "hex nut pocket depth leaves < 1.0 mm of overlay skin above the pocket");
-// Clearance hole depth must stay within JLC3DP SLA max (3× diameter).
+// Each segment depth must stay within JLC3DP SLA max (3× diameter).
 assert(!ENABLE_SCREW_INSERTS || screw_clear_depth <= screw_clear_d * 3,
-       "clearance hole depth exceeds JLC3DP SLA max (3× diameter)");
-// Bolt pocket depth at each position must stay within JLC3DP SLA max.
-// The pocket depth varies: front starts at z=0, back starts above the
-// chamfer. Checked per-position in the geometry module; the parameter
-// assertion here guards the worst case (full wall height with no chamfer).
-assert(!ENABLE_SCREW_INSERTS || screw_pocket_d * 3 >= 10,
-       "screw pocket diameter too small — max printable depth (3× dia) may not reach clearance");
+       "clearance segment exceeds JLC3DP SLA max (3× diameter)");
+// Reinforcement pad must not foul the plate.
+assert(!ENABLE_SCREW_INSERTS || screw_reinf <= plate_gap - 0.1,
+       "screw reinforcement pad exceeds plate_gap clearance");
 // Every screw position must have adequate outer cheek (pocket does not
 // breach the case outer face) and must sit on a wall (not floating in the
 // cavity). The pocket intentionally protrudes slightly into the cavity on
@@ -1662,16 +1662,14 @@ module overlay_magnet_pockets() {
 }
 
 // ─── Screw + nut geometry (optional, ENABLE_SCREW_INSERTS) ─────────────────
-// Through-bolt from tray bottom to overlay nut. Two printed segments meet
-// in the middle of the wall:
-//   1. Pocket (wide, from bottom/chamfer going UP) — bolt head sits here
-//   2. Clearance (narrow, from wall top going DOWN) — bolt shaft passes here
-// The step between them catches the bolt head.
+// 3-segment stepped through-bore from tray bottom to wall top. Each
+// segment stays within JLC3DP SLA's 3× depth limit. The bolt head
+// catches on the pocket→mid step; the shaft passes through mid+clear.
 //
 // Overlay: hex-shaped blind pocket (screw_nut_af × screw_nut_depth) cut
 //   from the underside, with tilt compensation as per magnet pockets.
 
-// Tilt-drift values.
+// Tilt-drift values (wall top surface is tilted).
 screw_clear_tilt_drift = screw_clear_d * tan(tilt_angle);
 screw_clear_cyl_h      = screw_clear_depth + screw_clear_tilt_drift + 0.2;
 screw_nut_tilt_drift   = screw_nut_ac * tan(tilt_angle);
@@ -1679,21 +1677,45 @@ screw_nut_cyl_h        = screw_nut_depth + screw_nut_tilt_drift + 0.2;
 
 module tray_screw_holes() {
     for (p = screw_positions()) {
-        // Clearance hole from wall top going DOWN. Tilt-compensated at the
-        // wall top surface (anchor to uphill edge).
+        // Clearance (top segment): from wall top going DOWN.
         z_top_hi = top_z(p[1] + screw_clear_d/2) - top_t + 0.1;
-        translate([p[0], p[1], z_top_hi - screw_clear_cyl_h])
+        clear_bot = z_top_hi - screw_clear_cyl_h;
+        translate([p[0], p[1], clear_bot])
             cylinder(d = screw_clear_d, h = screw_clear_cyl_h);
 
-        // Bolt head pocket from tray bottom going UP. Extends from below
-        // the tray bottom (z = -0.1) to 0.5 mm above the clearance hole
-        // bottom, so the two segments overlap and form a continuous hole.
-        // At back positions where the chamfer removes the bottom material,
-        // the pocket effectively starts at the chamfer surface — the lower
-        // part of the cylinder cuts through air.
-        pocket_top = z_top_hi - screw_clear_cyl_h + 0.5;
+        // Head catch point: where the pocket→mid step is.
+        wall_top_center = top_z(p[1]) - top_t;
+        pocket_top = wall_top_center + 1.3 - screw_bolt_length;
+
+        // Mid segment: from pocket_top to clearance bottom + overlap.
+        mid_top = clear_bot + 0.5;
+        translate([p[0], p[1], pocket_top - 0.01])
+            cylinder(d = screw_mid_d, h = mid_top - pocket_top + 0.01);
+
+        // Pocket (bottom segment): from below tray bottom to pocket_top.
+        // At back positions the lower portion cuts through the chamfer
+        // void — this is intentional (deboss, not protrusion).
         translate([p[0], p[1], -0.1])
             cylinder(d = screw_pocket_d, h = pocket_top + 0.1);
+    }
+}
+
+// Reinforcement pads: local wall thickening on the tray cavity inner
+// face at each screw position. Adds screw_reinf mm of material into
+// the cavity (within plate_gap clearance), improving the structural
+// support around the thin inner cheek of the screw bore.
+module tray_screw_reinforcement() {
+    for (p = screw_positions()) {
+        wall_top_center = top_z(p[1]) - top_t;
+        pad_w = screw_pocket_d + 2;
+        on_front = p[1] < outer_d / 2;
+        if (on_front) {
+            translate([p[0] - pad_w/2, wall_t, bottom_t])
+                cube([pad_w, screw_reinf, wall_top_center - bottom_t]);
+        } else {
+            translate([p[0] - pad_w/2, outer_d - wall_t - screw_reinf, bottom_t])
+                cube([pad_w, screw_reinf, wall_top_center - bottom_t]);
+        }
     }
 }
 
@@ -1786,6 +1808,9 @@ module case_tray() {
         // wall top. Unioned AFTER the cavity/slot/magnet cuts so its
         // geometry is preserved in full.
         if (ENABLE_OVERLAY_RABBET) tray_tongue_3d();
+
+        // Reinforcement pads on the cavity inner face at screw positions.
+        if (ENABLE_SCREW_INSERTS) tray_screw_reinforcement();
     }
 }
 

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -72,6 +72,11 @@ ENABLE_MAGNET_POCKETS = true;    // cut blind magnet pockets in the tray wall
                                  // magnetically (serviceable — overlay lifts
                                  // off for PCB access). Counts on N52 disc
                                  // magnets — see magnet_* params below.
+ENABLE_SCREW_INSERTS  = false;   // M1.6 hex nuts (glued) in hex pockets in the
+                                 // overlay underside + captive bolts threading
+                                 // up from inside the tray. 4 corner positions.
+                                 // Nothing visible externally. Mutually
+                                 // exclusive with ENABLE_MAGNET_POCKETS.
 
 // ─── Decorative trims (3D-print-only) ───────────────────────────────────────
 // Cosmetic embellishments with no mechanical role. Only practical on printed
@@ -508,6 +513,49 @@ function magnet_positions() = [
     [outer_w - magnet_inset,           outer_d - wall_t / 2],    // back-right
     [outer_w / 2,                      wall_t / 2],              // front-middle
     [outer_w / 2 + back_mid_offset,    outer_d - wall_t / 2],    // back-middle (offset to clear back tab 2)
+];
+
+// ─── Screw + nut pockets (optional, ENABLE_SCREW_INSERTS) ───────────────────
+// M1.6 hex nuts glued into hex-shaped pockets in the overlay underside;
+// M1.6 bolts thread upward through clearance holes in the tray wall top.
+// The bolt heads sit in counterbores recessed below the wall top so the
+// overlay seats flat. The hex pocket prevents the nut from spinning during
+// tightening; CA glue locks it permanently. 4 corners only — positive
+// mechanical engagement doesn't need mid-wall reinforcement to resist bow.
+//
+// SLA resin warps under heat, so heat-set inserts are not usable here.
+// Glued hex nuts are the correct fastener for this process.
+//
+// Hardware: M1.6 hex nut DIN 934 (3.2 mm AF, 1.3 mm thick),
+//           M1.6 × 3 mm socket head cap screw.
+// Length stack-up: the tilt-compensated counterbore is 1.78 mm deep at
+// the bolt center (not the nominal 1.5 mm — the cylinder is anchored to
+// the uphill edge of the tilted wall top, so it cuts 0.28 mm deeper at
+// center). Full traverse to nut top = 1.78 + 1.3 = 3.08 mm. A 3 mm bolt
+// gives 97% nut engagement; 4 mm would overshoot the pocket ceiling.
+// The traverse is identical at all 4 positions (front and back) because
+// both the counterbore anchor and the mating surface shift linearly with
+// the tilt — the Y-dependence cancels.
+screw_nut_af       = 3.4;    // hex pocket across-flats (3.2 mm M1.6 nut +
+                             // 0.2 mm SLA dimensional tolerance). Oriented
+                             // with flats parallel to wall faces so AF
+                             // constrains the wall-thickness cheek.
+screw_nut_depth    = 1.5;    // hex pocket depth (1.3 mm nut + 0.2 mm glue
+                             // headroom). Leaves top_t − 1.5 = 2.0 mm of
+                             // solid overlay above the pocket.
+screw_clear_d      = 2.0;    // M1.6 clearance hole through tray wall top
+screw_head_d       = 3.5;    // counterbore diameter (M1.6 SHCS head OD
+                             // 3.0 mm + 0.5 mm clearance)
+screw_head_depth   = 1.5;    // counterbore depth — recesses bolt head below
+                             // wall top so it doesn't foul the overlay
+screw_inset        = 13;     // corner inset (same geometry as magnet_inset)
+
+// Screw positions: 4 corners, same layout function pattern as magnet_positions.
+function screw_positions() = [
+    [screw_inset,                  wall_t / 2],              // front-left
+    [outer_w - screw_inset,        wall_t / 2],              // front-right
+    [screw_inset,                  outer_d - wall_t / 2],    // back-left
+    [outer_w - screw_inset,        outer_d - wall_t / 2],    // back-right
 ];
 
 // =============================================================================
@@ -976,6 +1024,129 @@ assert(!(ENABLE_MAGNET_POCKETS && ENABLE_OVERLAY_RABBET) ||
             if (lo < overlay_corner_r || hi > span - overlay_corner_r) 1]) == 0,
        "a magnet notch enters the overlay's rounded outer corner region");
 
+// ─── Screw + nut invariants (only enforced when ENABLE_SCREW_INSERTS) ───────
+// Mutually exclusive with magnets — both drill into the same wall-top real
+// estate, and the positions overlap.
+assert(!(ENABLE_SCREW_INSERTS && ENABLE_MAGNET_POCKETS),
+       "ENABLE_SCREW_INSERTS and ENABLE_MAGNET_POCKETS are mutually exclusive");
+// Hex nut across-corners (the bounding circle of the hex pocket).
+screw_nut_ac = screw_nut_af / cos(30);
+// Overlay wall cheek: hex pocket AF constrains wall-thickness direction.
+// Same 0.6 mm floor as magnet cheek (blind pocket in a solid body, not a
+// freestanding snap feature).
+assert(!ENABLE_SCREW_INSERTS || (wall_t - screw_nut_af) / 2 >= 0.6,
+       "hex nut pocket leaves < 0.6 mm cheek in overlay wall");
+// Tray wall cheek around the counterbore.
+assert(!ENABLE_SCREW_INSERTS || (tray_wall_t - screw_head_d) / 2 >= 0.8,
+       "screw counterbore leaves < 0.8 mm cheek in tray wall");
+// Hex pocket must not breach the overlay top surface.
+assert(!ENABLE_SCREW_INSERTS || screw_nut_depth <= top_t - 1.0,
+       "hex nut pocket depth leaves < 1.0 mm of overlay skin above the pocket");
+// Counterbore must not breach the tray floor. Same tilt-compensation check
+// as magnet pockets: anchor to uphill edge.
+screw_tilt_drift = screw_head_d * tan(tilt_angle);
+screw_cb_cyl_h   = screw_head_depth + screw_tilt_drift + 0.2;
+assert(!ENABLE_SCREW_INSERTS ||
+       len([for (p = screw_positions())
+            if (top_z(p[1] + screw_head_d/2) - top_t + 0.1 - screw_cb_cyl_h
+                < bottom_t + 2.0) 1]) == 0,
+       "screw counterbore bottom leaves less than 2 mm of wall material above the case floor");
+// Every screw position must sit entirely inside the wall ring. Use the
+// hex across-corners as the bounding radius (conservative — the hex
+// vertices extend further than the flats).
+assert(!ENABLE_SCREW_INSERTS ||
+       len([for (p = screw_positions())
+            let (r = max(screw_nut_ac, screw_head_d) / 2)
+            if (p[0] - r < 0.3 ||
+                p[0] + r > outer_w - 0.3 ||
+                p[1] - r < 0.3 ||
+                p[1] + r > outer_d - 0.3 ||
+                (p[0] + r > wall_t - 0.3 &&
+                 p[0] - r < outer_w - wall_t + 0.3 &&
+                 p[1] + r > wall_t - 0.3 &&
+                 p[1] - r < outer_d - wall_t + 0.3)) 1]) == 0,
+       "a screw position does not sit fully inside the wall ring material");
+// Screw positions must not collide with any gasket slot footprint.
+assert(!ENABLE_SCREW_INSERTS ||
+       len([for (p = screw_positions())
+            let (r = max(screw_nut_ac, screw_head_d) / 2)
+            for (bx = back_tab_cx)
+            let (sx1 = p2c_x(bx) - (tab_len + slot_tol)/2 - r,
+                 sx2 = p2c_x(bx) + (tab_len + slot_tol)/2 + r)
+            if (p[0] >= sx1 && p[0] <= sx2 &&
+                p[1] >= outer_d - wall_t - r) 1]) == 0,
+       "a back-wall screw position overlaps a back gasket slot");
+assert(!ENABLE_SCREW_INSERTS ||
+       len([for (p = screw_positions())
+            let (r = max(screw_nut_ac, screw_head_d) / 2)
+            for (fx = front_tab_cx)
+            let (sx1 = p2c_x(fx) - (tab_len + slot_tol)/2 - r,
+                 sx2 = p2c_x(fx) + (tab_len + slot_tol)/2 + r)
+            if (p[0] >= sx1 && p[0] <= sx2 &&
+                p[1] <= wall_t + r) 1]) == 0,
+       "a front-wall screw position overlaps a front gasket slot");
+// Screw positions must keep >= 2 mm cheek to USB cutout.
+assert(!ENABLE_SCREW_INSERTS ||
+       len([for (p = screw_positions())
+            let (r = max(screw_nut_ac, screw_head_d) / 2,
+                 cheek = abs(p[0] - p2c_x(usb_plate_x)) - usb_cut_w/2 - r)
+            if (p[1] >= outer_d - wall_t - r && cheek < 2.0) 1]) == 0,
+       "a back-wall screw position leaves < 2 mm cheek to the USB cutout");
+
+// ─── Screw × tongue auto-notching invariants ───────────────────────────────
+// Same pattern as magnet × tongue checks. The notch must clear the hex
+// across-corners extent (vertices extend further than the counterbore).
+screw_notch_extent = max(screw_nut_ac, screw_head_d);
+// Every screw position must be adjacent to a wall for the notch
+// classification to work.
+assert(!(ENABLE_SCREW_INSERTS && ENABLE_OVERLAY_RABBET) ||
+       len([for (p = screw_positions())
+            if (!(p[1] <= wall_t ||
+                  p[1] >= outer_d - wall_t ||
+                  p[0] <= wall_t ||
+                  p[0] >= outer_w - wall_t)) 1]) == 0,
+       "a screw position is not adjacent to any wall — tongue auto-notch would miss it");
+SCREW_NOTCH_SEP = 1.0;
+assert(!(ENABLE_SCREW_INSERTS && ENABLE_OVERLAY_RABBET) ||
+       len([for (p = screw_positions())
+            if (p[1] <= wall_t || p[1] >= outer_d - wall_t)
+              let (m_on_front = p[1] <= wall_t,
+                   m_lo = p[0] - screw_notch_extent/2 - notch_margin,
+                   m_hi = p[0] + screw_notch_extent/2 + notch_margin)
+              for (cx = m_on_front ? front_tab_cx : back_tab_cx)
+                let (s_lo = p2c_x(cx) - (tab_len + slot_tol)/2 - notch_margin,
+                     s_hi = p2c_x(cx) + (tab_len + slot_tol)/2 + notch_margin,
+                     gap  = (m_lo > s_hi) ? (m_lo - s_hi) :
+                            (s_lo > m_hi) ? (s_lo - m_hi) : -1)
+                if (gap < SCREW_NOTCH_SEP) 1]) == 0,
+       "a front/back-wall screw notch is within 1 mm of a gasket slot notch — tongue segment collapses");
+assert(!(ENABLE_SCREW_INSERTS && ENABLE_OVERLAY_RABBET) ||
+       len([for (p = screw_positions())
+            if ((p[0] <= wall_t || p[0] >= outer_w - wall_t) &&
+                !(p[1] <= wall_t || p[1] >= outer_d - wall_t))
+              let (m_on_left = p[0] <= wall_t,
+                   m_lo = p[1] - screw_notch_extent/2 - notch_margin,
+                   m_hi = p[1] + screw_notch_extent/2 + notch_margin,
+                   s_cy = m_on_left ? left_tab_cy : right_tab_cy,
+                   s_lo = p2c_y(s_cy) - (tab_len + slot_tol)/2 - notch_margin,
+                   s_hi = p2c_y(s_cy) + (tab_len + slot_tol)/2 + notch_margin,
+                   gap  = (m_lo > s_hi) ? (m_lo - s_hi) :
+                          (s_lo > m_hi) ? (s_lo - m_hi) : -1)
+              if (gap < SCREW_NOTCH_SEP) 1]) == 0,
+       "a left/right-wall screw notch is within 1 mm of the side gasket slot notch — tongue segment collapses");
+assert(!(ENABLE_SCREW_INSERTS && ENABLE_OVERLAY_RABBET) ||
+       len([for (p = screw_positions())
+            let (on_fb = p[1] <= wall_t || p[1] >= outer_d - wall_t,
+                 lo   = on_fb
+                        ? p[0] - screw_notch_extent/2 - notch_margin
+                        : p[1] - screw_notch_extent/2 - notch_margin,
+                 hi   = on_fb
+                        ? p[0] + screw_notch_extent/2 + notch_margin
+                        : p[1] + screw_notch_extent/2 + notch_margin,
+                 span = on_fb ? outer_w : outer_d)
+            if (lo < overlay_corner_r || hi > span - overlay_corner_r) 1]) == 0,
+       "a screw notch enters the overlay's rounded outer corner region");
+
 // The key_cap_clearance expansion must not erode the main-field ↔ arrow LDR
 // rib below its structural minimum. Gap at nominal MX spacing is 4.76 mm;
 // after 2×key_cap_clearance expansion the effective rib width is
@@ -1349,14 +1520,38 @@ module magnet_notch_footprints_2d(margin) {
     }
 }
 
+// 2D notch footprints for screw/nut pockets. Same pattern as
+// magnet_notch_footprints_2d but uses the bounding extent of the hex nut
+// across-corners or counterbore (whichever is larger) and screw_positions().
+module screw_notch_footprints_2d(margin) {
+    ring_w = rabbet_w + 2 * margin;
+    w      = screw_notch_extent + 2 * margin;
+    for (p = screw_positions()) {
+        if (p[1] <= wall_t) {
+            translate([p[0] - w / 2, wall_t - rabbet_w - margin])
+                square([w, ring_w]);
+        } else if (p[1] >= outer_d - wall_t) {
+            translate([p[0] - w / 2, outer_d - wall_t - margin])
+                square([w, ring_w]);
+        } else if (p[0] <= wall_t) {
+            translate([wall_t - rabbet_w - margin, p[1] - w / 2])
+                square([ring_w, w]);
+        } else if (p[0] >= outer_w - wall_t) {
+            translate([outer_w - wall_t - margin, p[1] - w / 2])
+                square([ring_w, w]);
+        }
+    }
+}
+
 // Slot-notched tongue / recess footprints — continuous locating ring with
 // 9 gaps where the gasket slots need a clear tab-descent path, plus one
-// additional gap at every magnet pocket when ENABLE_MAGNET_POCKETS is on.
+// additional gap at every magnet/screw pocket when enabled.
 module tongue_2d() {
     difference() {
         rabbet_inner_2d();
         gasket_slot_footprints_2d(notch_margin);
         if (ENABLE_MAGNET_POCKETS) magnet_notch_footprints_2d(notch_margin);
+        if (ENABLE_SCREW_INSERTS)  screw_notch_footprints_2d(notch_margin);
     }
 }
 module recess_2d() {
@@ -1364,6 +1559,7 @@ module recess_2d() {
         rabbet_outer_2d();
         gasket_slot_footprints_2d(notch_margin);
         if (ENABLE_MAGNET_POCKETS) magnet_notch_footprints_2d(notch_margin);
+        if (ENABLE_SCREW_INSERTS)  screw_notch_footprints_2d(notch_margin);
     }
 }
 
@@ -1453,6 +1649,54 @@ module overlay_magnet_pockets() {
     }
 }
 
+// ─── Screw + nut geometry (optional, ENABLE_SCREW_INSERTS) ─────────────────
+// Same tilt-compensation approach as magnet pockets: anchor the cutting
+// solid to the extreme wall-top over the feature footprint, extend by the
+// tilt drift so the full pocket depth is preserved at both edges.
+//
+// Tray: cylindrical counterbore (screw_head_d × screw_head_depth) at the
+//   wall top, plus a clearance through-hole (screw_clear_d) extending down
+//   into the cavity.
+// Overlay: hex-shaped blind pocket (screw_nut_af across-flats ×
+//   screw_nut_depth) cut from the overlay underside. The hex prevents the
+//   glued nut from rotating during bolt tightening. Flats are oriented
+//   parallel to the wall faces (default $fn=6 orientation has flats
+//   perpendicular to Y, which suits front/back wall positions).
+
+// Tilt-drift values for the screw features (same formula as magnet pockets).
+screw_nut_tilt_drift  = screw_nut_ac * tan(tilt_angle);
+screw_nut_cyl_h       = screw_nut_depth + screw_nut_tilt_drift + 0.2;
+screw_head_tilt_drift = screw_head_d * tan(tilt_angle);
+screw_head_cyl_h      = screw_head_depth + screw_head_tilt_drift + 0.2;
+
+module tray_screw_holes() {
+    for (p = screw_positions()) {
+        // Counterbore: top at uphill edge + 0.1 mm overshoot, extends down
+        // by head depth + drift.
+        z_top_hi = top_z(p[1] + screw_head_d/2) - top_t + 0.1;
+        translate([p[0], p[1], z_top_hi - screw_head_cyl_h])
+            cylinder(d = screw_head_d, h = screw_head_cyl_h);
+        // Clearance hole: from the bottom of the counterbore down through
+        // the wall into the cavity. Oversized length for a clean through-cut.
+        z_clear_top = z_top_hi - screw_head_cyl_h + 0.01;
+        translate([p[0], p[1], z_clear_top - 20])
+            cylinder(d = screw_clear_d, h = 20);
+    }
+}
+
+module overlay_nut_pockets() {
+    for (p = screw_positions()) {
+        // Hex pocket: bottom at downhill edge − 0.1 mm undershoot, extends
+        // up by nut depth + drift. $fn=6 creates a hex prism; the default
+        // orientation places flats perpendicular to Y (parallel to front/back
+        // wall faces). The `d` parameter sets the circumscribed circle
+        // (across-corners); we derive it from the desired across-flats.
+        z_bot_lo = top_z(p[1] - screw_nut_ac/2) - top_t - 0.1;
+        translate([p[0], p[1], z_bot_lo])
+            cylinder(d = screw_nut_ac, h = screw_nut_cyl_h, $fn = 6);
+    }
+}
+
 // ─── Back-wall chamfer protection ───────────────────────────────────────────
 // The large back-bottom chamfer (chamfer_back_bottom = cb) slopes the outer
 // back face at 45° from y = d - cb at z = 0 up to y = d at z = cb. Without
@@ -1523,6 +1767,9 @@ module case_tray() {
 
             // Optional: magnet pockets sunk into the wall tops.
             if (ENABLE_MAGNET_POCKETS) tray_magnet_pockets();
+
+            // Optional: screw clearance holes + counterbores in the wall tops.
+            if (ENABLE_SCREW_INSERTS) tray_screw_holes();
         }
 
         // Optional: overlay-locating tongue standing proud above the
@@ -1561,6 +1808,10 @@ module case_overlay() {
         // Optional: magnet pockets in the overlay underside, matching
         // the tray pockets across the seam.
         if (ENABLE_MAGNET_POCKETS) overlay_magnet_pockets();
+
+        // Optional: hex nut pockets in the overlay underside, matching
+        // the tray screw holes.
+        if (ENABLE_SCREW_INSERTS) overlay_nut_pockets();
 
         // Optional: recess cut into the overlay underside that accepts
         // the tray's tongue for lateral registration.
@@ -2230,6 +2481,9 @@ module case_overlay_chamfered() {
 
         // Magnet pockets
         if (ENABLE_MAGNET_POCKETS) overlay_magnet_pockets();
+
+        // Screw nut pockets
+        if (ENABLE_SCREW_INSERTS) overlay_nut_pockets();
 
         // Rabbet recess
         if (ENABLE_OVERLAY_RABBET) overlay_recess_3d();

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -535,7 +535,10 @@ screw_nut_depth    = 2.5;    // hex pocket depth (1.2 mm nut + margin for
                              // bolt tip and tolerance)
 screw_pocket_d     = 3.0;    // bottom segment — catches bolt head (2.6 mm
                              // M1.4 SHCS head + 0.4 mm clearance)
-screw_mid_d        = 2.5;    // intermediate segment
+screw_mid_d        = 2.0;    // intermediate segment (reduced from 2.5:
+                             // JLC3DP ±0.3 mm hole tolerance could grow
+                             // 2.5 to 2.8, larger than the 2.6 mm SHCS
+                             // head — bolt would fall through the step)
 screw_clear_d      = 2.0;    // top segment — M1.4 clearance from wall top
 screw_clear_depth  = 6.0;    // top segment depth (JLC max for 2 mm: 6 mm)
 screw_bolt_length  = 12;     // M1.4 × 12 mm (same length all 4 positions)

--- a/3d/case/test_configs.sh
+++ b/3d/case/test_configs.sh
@@ -108,28 +108,41 @@ echo ""
 # ---------------------------------------------------------------------------
 #
 # Feature toggles that guard conditional asserts:
-#   ENABLE_OVERLAY_RABBET:  guards assertions 16-21, and 29-32 (when combined
-#                           with ENABLE_MAGNET_POCKETS)
-#   ENABLE_MAGNET_POCKETS:  guards assertions 22-28, and 29-32 (when combined
-#                           with ENABLE_OVERLAY_RABBET)
+#   ENABLE_OVERLAY_RABBET:  guards rabbet-specific assertions and cross-feature
+#                           assertions when combined with magnets or screws
+#   ENABLE_MAGNET_POCKETS:  guards magnet-specific assertions and cross-feature
+#                           assertions when combined with ENABLE_OVERLAY_RABBET
+#   ENABLE_SCREW_INSERTS:   guards screw-specific assertions and cross-feature
+#                           assertions when combined with ENABLE_OVERLAY_RABBET.
+#                           Mutually exclusive with ENABLE_MAGNET_POCKETS.
 #   ENABLE_DECORATIVE_TRIMS: master gate for DECO_* sub-features (no asserts
 #                            currently, but geometry changes significantly)
 #   PRINT_MODE / PRINT_SUPPORTS: changes orientation/rib geometry
 #   SHOW_TRAY / SHOW_OVERLAY: selects which piece(s) to render
 #
-# The cross product of (rabbet × magnets × decoratives × print × show) gives
-# us full coverage of every conditional assert path.
+# The retention toggles (magnets/screws) are mutually exclusive, so valid
+# retention combos are: magnets-only, screws-only, neither. The full matrix
+# is (rabbet × retention × decoratives × print × show).
 
 # --- Section 1: Core feature toggle combinations ---
-echo "--- Section 1: Feature toggle matrix (rabbet × magnets × decoratives) ---"
+echo "--- Section 1: Feature toggle matrix (rabbet × retention × decoratives) ---"
 
+# Retention combos: magnets-only, screws-only, neither (magnets+screws is invalid)
 for rabbet in true false; do
-    for magnets in true false; do
+    for retention in magnets screws none; do
+        if [[ "$retention" == "magnets" ]]; then
+            magnets=true; screws=false
+        elif [[ "$retention" == "screws" ]]; then
+            magnets=false; screws=true
+        else
+            magnets=false; screws=false
+        fi
         for deco in true false; do
-            label="rabbet=$rabbet magnets=$magnets deco=$deco"
+            label="rabbet=$rabbet retention=$retention deco=$deco"
             run_config "$label" \
                 -D "ENABLE_OVERLAY_RABBET=$rabbet" \
                 -D "ENABLE_MAGNET_POCKETS=$magnets" \
+                -D "ENABLE_SCREW_INSERTS=$screws" \
                 -D "ENABLE_DECORATIVE_TRIMS=$deco"
         done
     done
@@ -198,18 +211,26 @@ for piece_label in tray overlay; do
         show_tray=false; show_overlay=true
     fi
     for rabbet in true false; do
-        for magnets in true false; do
+        for retention in magnets screws none; do
+            if [[ "$retention" == "magnets" ]]; then
+                magnets=true; screws=false
+            elif [[ "$retention" == "screws" ]]; then
+                magnets=false; screws=true
+            else
+                magnets=false; screws=false
+            fi
             for supports in true false; do
                 if [[ "$piece_label" == "overlay" && "$supports" == "true" ]]; then
                     continue
                 fi
-                label="print=$piece_label rabbet=$rabbet magnets=$magnets supports=$supports"
+                label="print=$piece_label rabbet=$rabbet retention=$retention supports=$supports"
                 run_config "$label" \
                     -D "PRINT_MODE=true" \
                     -D "SHOW_TRAY=$show_tray" \
                     -D "SHOW_OVERLAY=$show_overlay" \
                     -D "ENABLE_OVERLAY_RABBET=$rabbet" \
                     -D "ENABLE_MAGNET_POCKETS=$magnets" \
+                    -D "ENABLE_SCREW_INSERTS=$screws" \
                     -D "PRINT_SUPPORTS=$supports"
             done
         done


### PR DESCRIPTION
## Summary
- Adds `ENABLE_SCREW_INSERTS` toggle: M1.4 bolt + glued hex nut retention as an alternative to magnet pockets
- Hex nut pockets in the overlay underside, 3-segment stepped bore through tray wall columns (pocket → mid → clearance), bolt tightened from tray underside
- All bore segments within JLC3DP SLA 3× diameter depth limits; back-wall pockets deboss into the chamfer void
- M1.4 fasteners (3.0 mm nut AF) centered in wall — no reinforcement pads needed
- Tongue auto-notching, gasket slot clearance, and USB cutout cheek assertions for screw positions
- Hardware: 4× M1.4 × 12 mm SHCS + 4× M1.4 DIN 934 hex nut

## Pre-fab JLC3DP design review additions (2026-04-21)
- `screw_mid_d` reduced 2.5 → 2.0 mm: at 2.5 mm the ±0.3 mm hole tolerance could grow the mid segment to 2.8 mm — larger than the 2.6 mm SHCS head — so the bolt would drop straight through the step instead of catching. The fix keeps the head-catch step at 1.0 mm nominal / 0.4 mm worst-case.
- `build_stl.sh` now emits four STLs by default (`mkey_tray_{magnets,screws}.stl` + `mkey_overlay_{magnets,screws}.stl`) so the single JLC3DP order ships both retention variants. New `--retention magnets|screws|both` flag.
- Fixed 7 stale inline arithmetic comments in `case.scad` that drifted from `disp_cut_tol` (0.15 → 0.30) and `slot_tol` (0.4 → 0.6) bumps in earlier reviews. Executable code unchanged.
- Fixed JLC3DP submission note in `README.md`: debossed logo is on the back wall, not the side walls.

## Test plan
- [x] All 58 config combinations pass (`test_configs.sh`)
- [x] Full STL render with `ENABLE_SCREW_INSERTS=true` produces valid Nef polyhedron (Simple: yes)
- [x] Default config (magnets on, screws off) unaffected — byte-identical geometry to pre-review render
- [x] `build_stl.sh` produces all 4 STLs; `--retention` and `--piece` subset flags verified
- [ ] Visual inspection in OpenSCAD: bore segments visible in cross-section view