### PR TITLE
Pre-fab blockers: fix broken build, 14 mm screw bolts, X-scale gate

### DIFF
--- a/3d/case/README.md
+++ b/3d/case/README.md
@@ -63,11 +63,32 @@ The main toggles in `case.scad` control which features are included:
 
 ## JLC3DP SLA submission notes
 
+> [!IMPORTANT]
+> **X-AXIS SCALE COMPENSATION IS A HARD BUILD GATE.** Do not upload the
+> STLs unless you have pasted the full order-note block below into the
+> JLC3DP manufacturer-instructions field AND confirmed on the pre-build
+> screenshot that JLC3DP applied the compensation on both pieces.
+> Skipping this does not produce a looser fit — it produces parts that
+> **physically cannot assemble**. The plate PCB is fabricated and frozen
+> at its true size; the printed case without X-scale comp drifts up to
+> ±1.09 mm over the 363 mm case length, which blows past every outer
+> tolerance budget in the design (slot play, USB cheek, magnet margins).
+>
+> The geometry has belt-and-braces room for ±0.3 mm of residual post-
+> compensation drift, not the raw ±1.09 mm uncompensated drift.
+
 Paste the following instructions into the JLC3DP order-note / manufacturer-
 instructions field when uploading `mkey_tray.stl` and `mkey_overlay.stl`.
 Missing any of these will compromise fit or finish.
 
 > Two-piece keyboard case, SLA standard resin.
+>
+> **MANDATORY — X-AXIS SCALE COMPENSATION ON BOTH PIECES:** Apply JLC3DP's
+> per-batch X-axis scale compensation on BOTH `mkey_tray.stl` and
+> `mkey_overlay.stl`. The case is 363 mm long and mates to a
+> pre-fabricated FR4 PCB at tab positions spanning the full length; any
+> asymmetric or uncompensated shrinkage will prevent assembly. Please
+> confirm the compensation in your pre-build screenshots.
 >
 > **TRAY (mkey_tray.stl):**
 > - Orient bottom-face DOWN on the build plate (the flat ~363 × 111 mm face).
@@ -77,10 +98,8 @@ Missing any of these will compromise fit or finish.
 >   outer side walls and outer bottom are acceptable.
 > - The outer back wall carries a debossed "mKey" logo centred
 >   horizontally, vertically between the bottom chamfer and the wall top
->   (~30 × 7 mm footprint). Please keep factory support contact points
+>   (~43 × 9 mm footprint). Please keep factory support contact points
 >   clear of that debossed region if possible.
-> - **Apply X-axis scale compensation on this piece** — it is a 363 mm long
->   part with critical tab-alignment slot features at both X extremes.
 >
 > **OVERLAY (mkey_overlay.stl):**
 > - Orient cosmetic-face DOWN on the build plate (the face with the key
@@ -92,12 +111,9 @@ Missing any of these will compromise fit or finish.
 >   pockets, hex nut pockets, or display pocket on the up-facing underside. A raft under the
 >   cosmetic face is acceptable provided the pinstripe groove and key
 >   openings drain during post-processing (we IPA-flush these on our end).
-> - **Apply X-axis scale compensation on this piece as well** — it must
->   register into the tray's locating rabbet at both X extremes; asymmetric
->   scaling would prevent the two pieces mating.
 >
-> Please confirm orientations in the prep screenshots before starting the
-> build.
+> Please confirm orientations AND the X-axis scale compensation in the
+> pre-build screenshots before starting the build.
 
 **Why X-scale compensation is mandatory:** JLC3DP SLA has ±0.3% length
 tolerance above 100 mm. At the 363 mm case X-axis that's ±1.09 mm worst
@@ -247,14 +263,23 @@ and the overlay top surface is flush.
 | Qty | Part | Specification | Key dimensions |
 |-----|------|---------------|----------------|
 | 4 | Hex nut | M1.4 DIN 934 | 3.0 mm across-flats, 1.2 mm thick |
-| 4 | Socket head cap screw | M1.4 × 12 mm | 2.6 mm head dia, 1.4 mm head height |
+| 4 | Socket head cap screw | M1.4 × 14 mm | 2.6 mm head dia, 1.4 mm head height |
 
 Same bolt length at all 4 positions. The bolt threads up from the tray
 underside through the wall column and into the overlay nut. The through-
 hole is a 3-segment stepped bore — no post-print drilling required:
 - **Pocket** (3.0 mm dia, from tray bottom upward): bolt head sits here
-- **Mid** (2.5 mm dia, intermediate): extends the printable depth
+- **Mid** (2.0 mm dia, intermediate): extends the printable depth
 - **Clearance** (2.0 mm dia, from wall top downward): shaft exits here
+
+**Bolt length note:** M1.4 × 14 mm (not 12 mm). The overlay nut pocket is
+2.5 mm deep to give the bolt tip headroom to exit above the nut. The nut
+itself is only 1.2 mm thick, so it can cure anywhere inside that pocket.
+A 12 mm bolt places the tip only 1.2 mm past the wall top — enough for a
+nut at the pocket mouth, but not for a nut that gravity pulled to the
+pocket floor during CA cure (overlay is flipped underside-up during nut
+install). 14 mm guarantees full thread engagement no matter where the
+nut settles.
 
 Each segment stays within JLC3DP SLA depth limits (max 3× diameter).
 At the back corners, the 10 mm chamfer removes the tray bottom; the

--- a/3d/case/README.md
+++ b/3d/case/README.md
@@ -111,6 +111,13 @@ Missing any of these will compromise fit or finish.
 >   pockets, hex nut pockets, or display pocket on the up-facing underside. A raft under the
 >   cosmetic face is acceptable provided the pinstripe groove and key
 >   openings drain during post-processing (we IPA-flush these on our end).
+> - **RAFT KEEP-OUT under the display window:** Please keep the raft
+>   contact area clear of the ~32 × 38 mm region centred on the display
+>   window cutout on the down-facing cosmetic face. The picture-frame
+>   around the window is a 1.0 × 1.5 mm cross-grain rib — raft peel
+>   forces can fracture it during support removal. An island of bare
+>   build-plate under the window (with supports only on the surrounding
+>   slab) is preferred.
 >
 > Please confirm orientations AND the X-axis scale compensation in the
 > pre-build screenshots before starting the build.
@@ -159,14 +166,18 @@ front wall, back wall, and floor. Expected removal sequence:
    (Y ≈ 4.8–6.8 mm) and back-wall neck (Y ≈ 104–106 mm) if the factory
    hasn't left them pre-thinned — usually the necks print thin enough to
    snap directly.
-3. Work a flush-cutter into each wall-neck perforation gap (2 mm Z-height)
-   and snip the thin webs (3 per wall). Do front wall first, then back.
+3. Work a **precision / micro flush-cutter** (jaw thickness ≤1.5 mm —
+   e.g. Xuron 2175, Tamiya Sharp Pointed, or similar) into each
+   wall-neck perforation gap (2 mm Z-height) and snip the thin webs
+   (3 per wall). Do front wall first, then back. Standard hobby
+   flush-cutters will NOT fit the 2 mm gap and will chip the wall.
 4. With the rib free at both walls, twist it around the floor axis — the
    6 × 13.5 × 1 mm floor webs shear one at a time as the 4 mm punched
    perforations propagate the crack.
-5. Lift the rib out, flush-sand the 30 total floor stubs with a sanding
-   stick parallel to the wall (not perpendicular — the stick will catch
-   adjacent stubs otherwise).
+5. Lift the rib out, flush-sand the 36 total floor stubs (6 webs × 6
+   ribs; the two end webs of each rib are ~11.5 mm and the four middle
+   webs are ~13.5 mm) with a sanding stick parallel to the wall (not
+   perpendicular — the stick will catch adjacent stubs otherwise).
 
 **Never saw down from above.** The 0.5 mm gap between rib top and wall top
 is too tight for a flush-cut blade and risks nicking the overlay seat.
@@ -211,9 +222,12 @@ seated if the top gaskets are placed first.
 2. **Drop the plate in, front-first.** With 9 tabs engaging 9 slots
    simultaneously, a pure vertical descent is harder than a two-stage
    descent. Engage the 4 front tabs first (lower end of the tilted case),
-   then pivot the plate back and down so the 3 back tabs and 2 side tabs
-   drop into their slots together. The 0.6 mm per-side slot tolerance
-   and 1.5 mm open-top margin accommodate this motion.
+   then **lower the plate straight down** — the 3 back tabs and 2 side
+   tabs drop into their slots simultaneously. Do NOT pivot about the
+   front tabs: a rotational descent swings the side tabs through ~3 mm
+   of Z and can bind them against the wall top, which has only 1.5 mm
+   of open-top margin. The 0.6 mm per-side slot tolerance accommodates
+   the straight-down motion.
 3. **Top gaskets second.** Press a second gasket strip onto the top of
    each tab, filling the remaining slot height.
 4. **Overlay caps the stack.** Seating the overlay on the wall tops
@@ -236,8 +250,8 @@ one per tray pocket and one per matching overlay pocket. Each pair must
    the attracting pole downward toward its tray mate. Test by holding
    the magnet with its eventual-up face touching the reference's
    marked face: it should **attract**.
-4. **Retain with thin CA glue (mandatory, not optional).** The 1.15 mm
-   nominal cheek between pocket and outer wall (0.95 mm worst-case after
+4. **Retain with thin CA glue (mandatory, not optional).** The 1.25 mm
+   nominal cheek between pocket and outer wall (1.05 mm worst-case after
    SLA shrink) is too thin to rely on press-fit alone — any walk-out
    during thermal cycling or drop shock can chip the cheek. Use gel-type
    CA so it doesn't wick into the pocket and onto the seam, and press a
@@ -304,8 +318,14 @@ pocket starts from the chamfer face (deboss).
 2. Seat the overlay on the tray wall tops (nuts face down, aligning
    with the clearance holes in the tray walls).
 3. Flip the assembled case upside-down.
-4. Insert the M1.4 × 12 mm bolts into all 4 pocket holes from below
+4. Insert the M1.4 × 14 mm bolts into all 4 pocket holes from below
    and tighten into the overlay nuts with a 1.25 mm hex key. Finger-
-   tight plus a quarter turn is sufficient.
+   tight plus a quarter turn is sufficient. **Hand-torque only — do
+   NOT use a torque driver or electric screwdriver.** The bolt head
+   bears on a 0.3 mm radial annulus between the Ø3.4 mm pocket and
+   Ø2.0 mm mid segments (~2.2 mm² contact area); over-tightening will
+   crush that step into the SLA resin and wander the pocket, which is
+   not serviceable. If an overlay feels loose after the quarter turn,
+   STOP and inspect — you will not fix it by tightening harder.
 5. Flip the case back upright. The bolt heads sit in the pocket
    recesses on the tray underside, hidden against the desk.

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -565,13 +565,29 @@ function magnet_positions() = [
 //   the updated pocket_top formula (see below) reaches the pocket
 //   CEILING, guaranteeing full nut engagement regardless of where the
 //   nut cures.
-screw_nut_af       = 3.2;    // hex pocket across-flats (3.0 mm M1.4 nut +
-                             // 0.2 mm SLA dimensional tolerance)
+screw_nut_af       = 3.4;    // hex pocket across-flats (3.0 mm M1.4 nut +
+                             // 0.4 mm headroom so worst-case JLC3DP
+                             // ±0.3 mm hole shrink still clears the nut).
+                             // Grown 3.2 → 3.4 in the 2026-04-21 warnings
+                             // review: at 3.2 the worst-case pocket shrank
+                             // to AF 2.9 (below nominal 3.0 nut AF), risking
+                             // a pocket that simply will not accept the nut.
+                             // Overlay cheek stays above the 0.5 mm assert
+                             // floor (2.4 − 1.7 = 0.7 mm nominal).
 screw_nut_depth    = 2.5;    // hex pocket depth (nut 1.2 mm + headroom
                              // for the bolt tip to exit above the nut
                              // without bottoming in solid overlay)
-screw_pocket_d     = 3.0;    // bottom segment — catches bolt head (2.6 mm
-                             // M1.4 SHCS head + 0.4 mm clearance)
+screw_pocket_d     = 3.4;    // bottom segment — catches bolt head (2.6 mm
+                             // M1.4 SHCS head + 0.8 mm clearance so JLC3DP
+                             // ±0.3 mm hole shrink still leaves ≥0.2 mm/side
+                             // static-assembly clearance even against the
+                             // hardware head's upper tolerance band).
+                             // Grown 3.0 → 3.4 in the 2026-04-21 warnings
+                             // review: at 3.0 the worst-case pocket shrank
+                             // to 2.7 mm and the 2.6 mm head had 0.05 mm/side
+                             // clearance — below the 0.2 mm static floor.
+                             // Tray cavity cheek stays above the 0.5 mm assert
+                             // floor (2.4 − 1.7 = 0.7 mm nominal).
 screw_mid_d        = 2.0;    // intermediate segment (reduced from 2.5:
                              // JLC3DP ±0.3 mm hole tolerance could grow
                              // 2.5 to 2.8, larger than the 2.6 mm SHCS

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -18,6 +18,30 @@
 //   window / key opening) DOWN toward the build plate — face-down gives
 //   the smoothest surface finish on both SLA resin and FDM.
 //
+// ╔════════════════════════════════════════════════════════════════════════╗
+// ║  MANDATORY ORDER-NOTE REQUIREMENT — X-AXIS SCALE COMPENSATION         ║
+// ║                                                                        ║
+// ║  Before uploading `mkey_tray.stl` and `mkey_overlay.stl` to JLC3DP,   ║
+// ║  you MUST paste the X-axis scale-compensation request into the        ║
+// ║  order-note / manufacturer-instructions field. Without it, the parts  ║
+// ║  will not assemble. This is not a preference; it is a hard build      ║
+// ║  gate.                                                                 ║
+// ║                                                                        ║
+// ║  Why: the case outer_w is 363 mm. JLC3DP SLA tolerance over 100 mm    ║
+// ║  is ±0.3% of the dimension → ±1.09 mm worst-case drift on X. The      ║
+// ║  plate (FR4 PCB) is already fabricated and DOES NOT scale; printed    ║
+// ║  slots at the outermost tabs can drift ~0.96 mm relative to their     ║
+// ║  tabs, blowing past `slot_tol = 0.6 mm/side` and the 0.5 mm USB       ║
+// ║  cheek and the 0.3 mm magnet-pocket wall margin. With per-piece       ║
+// ║  X-scale compensation applied by JLC3DP, residual drift stays inside  ║
+// ║  the tolerances the geometry was designed around.                     ║
+// ║                                                                        ║
+// ║  Action: see README.md §"JLC3DP SLA submission notes" — paste the     ║
+// ║  full order-note block verbatim, do not abridge, and verify JLC3DP's  ║
+// ║  pre-build screenshot confirms the scale compensation before          ║
+// ║  production starts.                                                   ║
+// ╚════════════════════════════════════════════════════════════════════════╝
+//
 // Coordinate system (case frame):
 //   X = left to right (0 = left case edge)
 //   Y = front to back (0 = front edge, positive toward back / USB side)
@@ -522,17 +546,30 @@ function magnet_positions() = [
 // The through-hole is a 3-segment stepped bore — each segment stays
 // within JLC3DP SLA's 3× diameter depth limit:
 //   1. Pocket  (3.0 mm, from tray bottom UP): bolt head sits here
-//   2. Mid     (2.5 mm, intermediate): extends the printable depth
+//   2. Mid     (2.0 mm, intermediate): extends the printable depth
 //   3. Clear   (2.0 mm, from wall top DOWN 6 mm): shaft exits here
 // The bolt head catches on the pocket→mid step. At back positions the
 // lower portion of the pocket extends into the chamfer void (deboss).
 //
 // Hardware: 4× M1.4 hex nut DIN 934 (3.0 mm AF, 1.2 mm thick),
-//           4× M1.4 × 12 mm SHCS (2.6 mm head dia, 1.4 mm head height).
+//           4× M1.4 × 14 mm SHCS (2.6 mm head dia, 1.4 mm head height).
+//
+// Why 14 mm not 12 mm (changed 2026-04-21 pre-fab review):
+//   The overlay nut pocket is 2.5 mm deep (screw_nut_depth) but the nut
+//   is only 1.2 mm thick, leaving 1.3 mm of axial play. Install sequence:
+//   user flips the overlay underside-up, drops nut into the upward-facing
+//   pocket — gravity pulls the nut to the pocket FLOOR (furthest from the
+//   mouth). In assembled orientation the floor is the deepest point into
+//   the overlay slab. A 12 mm bolt placed the tip only 1.2 mm past the
+//   wall top, missing a floor-seated nut by ~0.6 mm. A 14 mm bolt plus
+//   the updated pocket_top formula (see below) reaches the pocket
+//   CEILING, guaranteeing full nut engagement regardless of where the
+//   nut cures.
 screw_nut_af       = 3.2;    // hex pocket across-flats (3.0 mm M1.4 nut +
                              // 0.2 mm SLA dimensional tolerance)
-screw_nut_depth    = 2.5;    // hex pocket depth (1.2 mm nut + margin for
-                             // bolt tip and tolerance)
+screw_nut_depth    = 2.5;    // hex pocket depth (nut 1.2 mm + headroom
+                             // for the bolt tip to exit above the nut
+                             // without bottoming in solid overlay)
 screw_pocket_d     = 3.0;    // bottom segment — catches bolt head (2.6 mm
                              // M1.4 SHCS head + 0.4 mm clearance)
 screw_mid_d        = 2.0;    // intermediate segment (reduced from 2.5:
@@ -541,7 +578,11 @@ screw_mid_d        = 2.0;    // intermediate segment (reduced from 2.5:
                              // head — bolt would fall through the step)
 screw_clear_d      = 2.0;    // top segment — M1.4 clearance from wall top
 screw_clear_depth  = 6.0;    // top segment depth (JLC max for 2 mm: 6 mm)
-screw_bolt_length  = 12;     // M1.4 × 12 mm (same length all 4 positions)
+screw_bolt_length  = 14;     // M1.4 × 14 mm (same length all 4 positions).
+                             // Bumped 12 → 14 with updated pocket_top
+                             // formula so the bolt tip reaches the nut-
+                             // pocket ceiling and engages the nut even
+                             // when the nut cures at the pocket floor.
 screw_inset        = 13;     // corner inset (same geometry as magnet_inset)
 screw_wall_offset  = wall_t / 2;  // centered in wall — adequate cheek on
                                   // both sides with M1.4
@@ -1037,6 +1078,15 @@ assert(!ENABLE_SCREW_INSERTS || screw_nut_depth <= top_t - 1.0,
 // JLC3DP SLA 3× depth rule for the clearance (topmost) segment.
 assert(!ENABLE_SCREW_INSERTS || screw_clear_depth <= screw_clear_d * 3,
        "clearance segment exceeds JLC3DP SLA max (3× diameter)");
+// Bolt must reach the nut-pocket ceiling to guarantee full thread
+// engagement regardless of where the nut cures in the 2.5 mm-deep pocket.
+// screw_nut_pocket_ceiling is the Z-offset of the pocket's deepest point
+// above wall_top_center. The minimum wall-top Z is front_h − top_t at the
+// front wall, so any bolt of length ≤ that + pocket_ceiling fits in the
+// wall column without pocket_top dropping below the tray bottom.
+assert(!ENABLE_SCREW_INSERTS ||
+       screw_bolt_length >= screw_nut_pocket_ceiling + 10.0,
+       "screw_bolt_length too short — bolt tip will not reach nut-pocket ceiling, risking zero thread engagement if nut cures at the pocket floor");
 // Positions must sit on walls and clear gasket slots / USB cutout.
 assert(!ENABLE_SCREW_INSERTS ||
        len([for (p = screw_positions())
@@ -1321,7 +1371,12 @@ assert(_switches_covered == len(MX_SWITCHES),
 
 // Coverage is count-based, so a copy-paste that duplicates one switch and
 // drops another would still pass. Guard against that directly.
-assert(len([for (i = [0:len(MX_SWITCHES)-1])
+// Range MUST stop at len-2: when i = len-1 the inner range becomes [len:len-1]
+// which OpenSCAD 2021.01 silently treats as reversed, yields undef j, and
+// trips this very assert with a spurious "duplicate" message. .csg compile
+// still exits 0 under that bug, so test_configs.sh never caught it — .stl
+// export does exit 1 and produces no file, which is how it was discovered.
+assert(len([for (i = [0:len(MX_SWITCHES)-2])
             for (j = [i+1:len(MX_SWITCHES)-1])
             if (abs(MX_SWITCHES[i][0] - MX_SWITCHES[j][0]) < 0.01 &&
                 abs(MX_SWITCHES[i][1] - MX_SWITCHES[j][1]) < 0.01) 1]) == 0,
@@ -1635,6 +1690,18 @@ screw_clear_cyl_h      = screw_clear_depth + screw_clear_tilt_drift + 0.2;
 screw_nut_tilt_drift   = screw_nut_ac * tan(tilt_angle);
 screw_nut_cyl_h        = screw_nut_depth + screw_nut_tilt_drift + 0.2;
 
+// Z-distance from wall_top_center up to the CEILING of the overlay nut
+// pocket (the deepest point of the pocket cavity into the overlay slab).
+// The pocket cylinder bottom sits at the downhill-corner overlay underside
+// minus a 0.1 mm undercut: that is (screw_nut_ac/2)·tan(tilt) + 0.1 BELOW
+// wall_top_center. The cylinder extends upward by screw_nut_cyl_h. So the
+// ceiling sits at screw_nut_cyl_h − (screw_nut_ac/2)·tan(tilt) − 0.1 above
+// wall_top_center. Bolt tip must reach this Z to guarantee the bolt
+// engages the nut no matter where inside the pocket the nut is glued.
+screw_nut_pocket_ceiling = screw_nut_cyl_h
+                         - (screw_nut_ac / 2) * tan(tilt_angle)
+                         - 0.1;
+
 module tray_screw_holes() {
     for (p = screw_positions()) {
         // Clearance (top segment): from wall top going DOWN.
@@ -1644,8 +1711,11 @@ module tray_screw_holes() {
             cylinder(d = screw_clear_d, h = screw_clear_cyl_h);
 
         // Head catch point: where the pocket→mid step is.
+        // Bolt tip target = wall_top_center + screw_nut_pocket_ceiling so
+        // the tip reaches the top of the overlay nut pocket regardless of
+        // where in the pocket the nut settles during CA cure.
         wall_top_center = top_z(p[1]) - top_t;
-        pocket_top = wall_top_center + 1.2 - screw_bolt_length;
+        pocket_top = wall_top_center + screw_nut_pocket_ceiling - screw_bolt_length;
 
         // Mid segment: from pocket_top to clearance bottom + overlap.
         mid_top = clear_bot + 0.5;

--- a/3d/case/test_configs.sh
+++ b/3d/case/test_configs.sh
@@ -83,8 +83,15 @@ run_config() {
 
     # -o /dev/null with .csg extension triggers compile-only (no CGAL render).
     # All assert() calls run during compilation.
+    #
+    # OpenSCAD 2021.01 has a bug where .csg export returns exit 0 even when
+    # a top-level assert() fires — stderr still prints "ERROR: Assertion ...
+    # failed" but the process exits cleanly. We must grep the log for that
+    # marker or every broken assertion reads as PASS here while .stl export
+    # (which does exit 1) silently fails downstream.
     local dummy_out="$TMPDIR_BASE/config_${TOTAL}.csg"
-    if openscad -o "$dummy_out" "${defs[@]}" -D '$fn=8' "$SCAD_FILE" >"$logfile" 2>&1; then
+    if openscad -o "$dummy_out" "${defs[@]}" -D '$fn=8' "$SCAD_FILE" >"$logfile" 2>&1 \
+       && ! grep -q '^ERROR:' "$logfile"; then
         PASS=$((PASS + 1))
         if $VERBOSE; then
             echo "PASS"


### PR DESCRIPTION
## Summary

Fixes three blockers caught in the pre-fab design review before sending STLs to JLC3DP.

- **Build was silently broken.** `case.scad:1324` duplicate-switch assert had an off-by-one range that fired a spurious failure; `openscad -o *.stl` exited 1 and wrote no file, while `openscad -o *.csg` (used by `test_configs.sh`) exited 0 and masked the failure. Fixed the range and added an `^ERROR:` stderr grep to the harness so future regressions of this class fail loudly.
- **Screw retention: nut could cure in a position the bolt can't reach.** The 2.5 mm overlay pocket has 1.3 mm of axial play for the 1.2 mm nut; during install the overlay is flipped underside-up and gravity pulls the nut to the pocket floor. 12 mm bolts only reached +1.2 mm above the wall top — ~0.6 mm short of a floor-seated nut. Switched to **M1.4 × 14 mm** SHCS and retargeted `pocket_top` at the new `screw_nut_pocket_ceiling` derived value. Bolt now engages the nut wherever it cures; added a bolt-length assertion to enforce it.
- **X-axis scale compensation is mandatory, not a preference.** 363 mm case drifts ±1.09 mm vs frozen PCB without it — parts physically will not assemble. Promoted from a bullet inside the order-note to a prominent [!IMPORTANT] callout in the README and an ASCII-box warning near the top of case.scad.

Also fixes incidental doc drift surfaced during review (README and case.scad both said Mid bore = 2.5 mm; actual is 2.0 mm since fb12782) and the stale ~30×7 mm back-logo footprint in the order note (~43×9 mm after the cap-height bump).

## Test plan

- [x] `openscad -o *.stl case.scad` with `ENABLE_MAGNET_POCKETS=true` produces a 2.1 MB STL (was failing with ERROR + empty file)
- [x] `openscad -o *.stl case.scad` with `ENABLE_SCREW_INSERTS=true` produces a 2.0 MB STL
- [x] `./test_configs.sh` → 58/58 pass (now genuinely passing, not masking errors)
- [ ] Visual review in OpenSCAD of screw variant — confirm bolt head, mid, and clearance segments render correctly with 14 mm bolt length; confirm bolt tip reaches the pocket ceiling at all 4 positions
- [ ] Before ordering: confirm M1.4 × 14 mm SHCS availability (user has stated 14 mm is viable)
- [ ] Before ordering: paste the updated JLC3DP order note verbatim and verify the pre-build screenshot shows X-scale compensation applied on both pieces