### PR TITLE
pre-fab: blunt chamfer fill apex for JLC3DP min wall

### DIFF
--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -408,7 +408,13 @@ tray_corner_r    = 0.75;   // outer corner radius of tray (overridden by chamfer
 chamfer_top_primary   = 1.2;   // mm, 45° chamfer on overlay/tray top edges (1.0-1.5 spec)
 chamfer_edge_break    = 0.2;   // mm, minimum chamfer on all remaining sharp edges
 chamfer_back_bottom   = 10.0;  // mm, large triangular chamfer on tray bottom back edge (must be < pad_inset)
+chamfer_fill_min_y    = 2.0;   // mm, minimum Y-depth of chamfer fill at apex — prevents
+                               // knife-edge thinness that violates JLC3DP SLA ≥ 2.0 mm wall
 ENABLE_CHAMFERS       = true;  // master switch for all chamfer geometry
+assert(chamfer_fill_min_y <= chamfer_back_bottom - bottom_t,
+       str("chamfer_fill_min_y (", chamfer_fill_min_y,
+           " mm) exceeds chamfer fill base depth (",
+           chamfer_back_bottom - bottom_t, " mm)"));
 
 // ─── Overlay locating rabbet (optional, ENABLE_OVERLAY_RABBET) ──────────────
 // INVERTED ("tongue") geometry: a small ridge of wood stands proud ABOVE
@@ -1868,30 +1874,25 @@ module overlay_nut_pockets() {
 // becomes a negative number (a through-slit).
 //
 // Fix: locally pull the cavity back inner face forward so the back wall
-// stays a uniform tray_wall_t slab inside the chamfer band. The inner face
-// is chamfered parallel to the outer chamfer, offset by tray_wall_t, and
-// meets the straight upper cavity exactly at z = cb (no step). The chamfer
-// region at the back of the cavity (z = bottom_t..cb, roughly 7×5.3 mm in
-// y×z cross-section) is solid material. Nothing in the original cavity is
-// lost: the plate + PCB components all sit at z ≥ bottom_t + depth_below
-// (= 11.5 mm at the front, higher at the back), so the filled-in triangle
-// is empty cavity space that was never used.
+// stays at least tray_wall_t inside the chamfer band. The fill cross-section
+// is a trapezoid (not a triangle): at z = cb the inner face sits
+// chamfer_fill_min_y mm forward of cavity_back_y so the apex never thins
+// below the JLC3DP SLA minimum wall. The wall grows from tray_wall_t at
+// z = bottom_t to tray_wall_t + chamfer_fill_min_y at z = cb. The extra
+// thickness eats into unused cavity space (plate + PCB sit at z ≥ 11.5 mm).
 module back_wall_chamfer_fill() {
     cb = chamfer_back_bottom;
     cavity_back_y = outer_d - wall_t;           // straight cavity back (z ≥ cb)
     front_bot_y   = cavity_back_y - (cb - bottom_t);  // inner chamfer foot @ z=bottom_t
-    // X covers the full cavity width plus a 1 mm overhang each side so the
-    // triangular prism cleanly subtracts from the rectangular cavity cutout.
+    min_y         = chamfer_fill_min_y;
     x_lo = wall_t - 1;
     x_hi = outer_w - wall_t + 1;
     eps  = 0.001;
     hull() {
-        // Top apex edge at (y = cavity_back_y, z = cb), spanning X.
-        // Extend 0.01 mm above cb so the fill overlaps the straight
-        // cavity wall and avoids a coplanar tessellation seam.
-        translate([x_lo, cavity_back_y - eps, cb])
-            cube([x_hi - x_lo, eps, 0.01 + eps]);
-        // Bottom base rectangle at z = bottom_t, spanning full triangle base in Y.
+        // Top shelf at z = cb: min_y deep in Y (blunted, no knife-edge).
+        translate([x_lo, cavity_back_y - min_y, cb])
+            cube([x_hi - x_lo, min_y + eps, eps]);
+        // Bottom base rectangle at z = bottom_t, spanning full trapezoid base in Y.
         translate([x_lo, front_bot_y, bottom_t])
             cube([x_hi - x_lo, cavity_back_y - front_bot_y, eps]);
     }

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -1262,6 +1262,17 @@ assert(usb_cut_z_bot >= bottom_t + 0.3,
        "USB cutout pierces (or touches) the case floor within fab slop");
 assert(usb_cut_z_top <= back_wall_top_z - 0.3,
        "USB cutout pierces the tray wall top at the back within fab slop");
+// Chamfer fill ramp must stay below the USB cutout and the PCB bottom.
+assert(!ENABLE_CHAMFERS ||
+       chamfer_back_bottom + chamfer_fill_min_y < usb_cut_z_bot,
+       str("chamfer fill ramp top (z=", chamfer_back_bottom + chamfer_fill_min_y,
+           ") reaches USB cutout bottom (z=", usb_cut_z_bot, ")"));
+assert(!ENABLE_CHAMFERS ||
+       chamfer_back_bottom + chamfer_fill_min_y + stack_clearance
+           <= pcb_top_z - pcb_t,
+       str("chamfer fill ramp top (z=", chamfer_back_bottom + chamfer_fill_min_y,
+           ") + stack_clearance (", stack_clearance,
+           ") breaches PCB bottom (z=", pcb_top_z - pcb_t, ")"));
 
 // ─── Installed gasket scheme sanity ──────────────────────────────────────
 // Bottom gasket must fit within the slot_bot_below_plate budget at the

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -1874,12 +1874,9 @@ module overlay_nut_pockets() {
 // becomes a negative number (a through-slit).
 //
 // Fix: locally pull the cavity back inner face forward so the back wall
-// stays at least tray_wall_t inside the chamfer band. The fill cross-section
-// is a trapezoid (not a triangle): at z = cb the inner face sits
-// chamfer_fill_min_y mm forward of cavity_back_y so the apex never thins
-// below the JLC3DP SLA minimum wall. The wall grows from tray_wall_t at
-// z = bottom_t to tray_wall_t + chamfer_fill_min_y at z = cb. The extra
-// thickness eats into unused cavity space (plate + PCB sit at z ≥ 11.5 mm).
+// stays at least tray_wall_t inside the chamfer band. The fill is a
+// trapezoid (z = bottom_t..cb) topped by a ramp (z = cb..cb + min_y)
+// that returns flush to cavity_back_y — no step, no knife-edge.
 module back_wall_chamfer_fill() {
     cb = chamfer_back_bottom;
     cavity_back_y = outer_d - wall_t;           // straight cavity back (z ≥ cb)
@@ -1888,13 +1885,22 @@ module back_wall_chamfer_fill() {
     x_lo = wall_t - 1;
     x_hi = outer_w - wall_t + 1;
     eps  = 0.001;
-    hull() {
-        // Top shelf at z = cb: min_y deep in Y (blunted, no knife-edge).
-        translate([x_lo, cavity_back_y - min_y, cb])
-            cube([x_hi - x_lo, min_y + eps, eps]);
-        // Bottom base rectangle at z = bottom_t, spanning full trapezoid base in Y.
-        translate([x_lo, front_bot_y, bottom_t])
-            cube([x_hi - x_lo, cavity_back_y - front_bot_y, eps]);
+    union() {
+        // Main fill: trapezoid from z = bottom_t to z = cb.
+        hull() {
+            translate([x_lo, cavity_back_y - min_y, cb])
+                cube([x_hi - x_lo, min_y + eps, eps]);
+            translate([x_lo, front_bot_y, bottom_t])
+                cube([x_hi - x_lo, cavity_back_y - front_bot_y, eps]);
+        }
+        // Ramp: returns the blunted shelf to cavity_back_y over min_y mm
+        // of Z so the transition is a 45° slope instead of a step.
+        hull() {
+            translate([x_lo, cavity_back_y - min_y, cb])
+                cube([x_hi - x_lo, min_y + eps, eps]);
+            translate([x_lo, cavity_back_y - eps, cb + min_y])
+                cube([x_hi - x_lo, eps, eps]);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- The back-wall chamfer fill was a triangle tapering to zero Y-depth at z = cb, creating knife-edge sections below JLC3DP SLA's 2.0 mm minimum wall thickness (visible on both the back internal wall and near the USB port)
- Replaced with a trapezoid cross-section topped by a 45° ramp: new `chamfer_fill_min_y = 2.0 mm` parameter keeps the apex blunted, and the ramp smoothly returns the inner face to `cavity_back_y` over `min_y` mm of Z — no step, no knife-edge
- Extra thickness eats into unused cavity space below the plate/PCB stack (components sit at z ≥ 13.1 mm, ramp tops out at z = 12.0 mm)

## Commits
1. **Blunt chamfer fill apex** — trapezoid replaces triangle, `chamfer_fill_min_y` parameter + base assertion
2. **Add 45° ramp** — eliminates the visible step at z = cb with a smooth slope back to the straight cavity wall
3. **Assert ramp clearance** — guards ramp top vs USB cutout bottom (0.87 mm gap) and PCB bottom (2.82 mm + stack_clearance margin)

## Verified
- [x] OpenSCAD compiles clean — no assertion failures, valid manifold
- [x] USB cutout position unchanged (Z: 12.87–20.87 mm)
- [x] All outer dimensions unchanged (369.4 × 117.0 mm)
- [x] Back logo position identical (`chamfer_back_bottom` unchanged)
- [x] Screw bore 3× depth assertions still pass
- [x] Ramp top (z=12.0) clears USB cutout bottom (z=12.87) and PCB bottom (z=16.32)