### PR TITLE
pre-fab: add anti-warp snap-off tie bars to overlay

### DIFF
--- a/3d/case/build_stl.sh
+++ b/3d/case/build_stl.sh
@@ -133,7 +133,6 @@ render_piece() {
         -D "SHOW_PLATE=false" \
         -D "SHOW_DISPLAY=false" \
         -D "PRINT_SUPPORTS=$SUPPORTS" \
-        -D "PRINT_OVERLAY_SUPPORTS=$SUPPORTS" \
         -D "ENABLE_MAGNET_POCKETS=$magnets" \
         -D "ENABLE_SCREW_INSERTS=$screws" \
         -D "\$fn=$FN" \

--- a/3d/case/build_stl.sh
+++ b/3d/case/build_stl.sh
@@ -16,14 +16,14 @@
 # Options:
 #   --piece tray|overlay|both       Which piece(s) to export (default: both)
 #   --retention magnets|screws|both Which retention variant(s) (default: both)
-#   --supports                      Add breakaway cross-braces to the tray
+#   --supports                      Add breakaway supports (tray ribs + overlay bars)
 #   --fn N                          Override circle resolution (default: 128)
 #   --outdir DIR                    Output directory (default: current directory)
 #   -h, --help                      Show this help message
 #
 # Examples:
 #   ./build_stl.sh                            # All 4 STLs, no supports
-#   ./build_stl.sh --supports                 # All 4, tray with anti-warp ribs
+#   ./build_stl.sh --supports                 # All 4, with anti-warp supports
 #   ./build_stl.sh --retention magnets        # Magnet pair only
 #   ./build_stl.sh --piece tray --retention screws  # Just the screw tray
 
@@ -133,6 +133,7 @@ render_piece() {
         -D "SHOW_PLATE=false" \
         -D "SHOW_DISPLAY=false" \
         -D "PRINT_SUPPORTS=$SUPPORTS" \
+        -D "PRINT_OVERLAY_SUPPORTS=$SUPPORTS" \
         -D "ENABLE_MAGNET_POCKETS=$magnets" \
         -D "ENABLE_SCREW_INSERTS=$screws" \
         -D "\$fn=$FN" \

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -71,10 +71,8 @@ EXPLODE         = 2;       // set >0 to separate overlay from tray (mm)
 // When exporting STLs for manufacturing, set PRINT_MODE=true and render one
 // piece at a time (SHOW_TRAY xor SHOW_OVERLAY).
 PRINT_MODE      = false;   // flip to true (or pass -D) for STL export
-PRINT_SUPPORTS  = false;   // add internal anti-warp rib walls to the tray cavity
-                           // (grow with the walls during SLA build, resist bowing)
-PRINT_OVERLAY_SUPPORTS = false;  // add snap-off tie bars across the key opening void
-                                 // in the overlay (resist frame warp during SLA cure)
+PRINT_SUPPORTS  = false;   // add anti-warp supports: tray cavity ribs and
+                           // overlay tie bars across the key opening void
 
 // ─── Feature toggles (per-fabrication-method overrides) ─────────────────────
 // DESIGN NOTE — why these are toggles:
@@ -2747,7 +2745,7 @@ module case_overlay_print() {
     rotate([-tilt_angle, 0, 0])
     translate([0, 0, -(front_h - top_t)]) {
         case_overlay_finished();
-        if (PRINT_OVERLAY_SUPPORTS) overlay_support_bars();
+        if (PRINT_SUPPORTS) overlay_support_bars();
     }
 }
 
@@ -3030,7 +3028,7 @@ _overlay_bar_pitch = (_overlay_void_x1 - _overlay_void_x0) / (_overlay_bar_count
 overlay_bar_cx = [for (i = [1 : _overlay_bar_count])
                       _overlay_void_x0 + i * _overlay_bar_pitch];
 
-if (PRINT_OVERLAY_SUPPORTS) {
+if (PRINT_SUPPORTS) {
     assert(overlay_bar_h >= 0.8,
            str("Overlay bar height ", overlay_bar_h,
                " mm below JLC3DP 0.8 mm feature minimum"));

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -73,6 +73,8 @@ EXPLODE         = 2;       // set >0 to separate overlay from tray (mm)
 PRINT_MODE      = false;   // flip to true (or pass -D) for STL export
 PRINT_SUPPORTS  = false;   // add internal anti-warp rib walls to the tray cavity
                            // (grow with the walls during SLA build, resist bowing)
+PRINT_OVERLAY_SUPPORTS = false;  // add snap-off tie bars across the key opening void
+                                 // in the overlay (resist frame warp during SLA cure)
 
 // ─── Feature toggles (per-fabrication-method overrides) ─────────────────────
 // DESIGN NOTE — why these are toggles:
@@ -2743,8 +2745,10 @@ module case_overlay_print() {
     rotate([0, 180, 0])
     translate([0, 0, -top_t])
     rotate([-tilt_angle, 0, 0])
-    translate([0, 0, -(front_h - top_t)])
+    translate([0, 0, -(front_h - top_t)]) {
         case_overlay_finished();
+        if (PRINT_OVERLAY_SUPPORTS) overlay_support_bars();
+    }
 }
 
 // ─── Print-oriented tray ────────────────────────────────────────────────────
@@ -2980,6 +2984,94 @@ module print_support_rib(cx) {
                        z_floor - 0.01])
                 cube([rib_t + 0.02, _cb_d + 0.01, _cb_h + 0.01]);
         }
+    }
+}
+
+// ─── Overlay anti-warp tie bars ─────────────────────────────────────────────
+// Flat rectangular bars on the underside of the overlay spanning the main key
+// opening void in the Y direction. They tie the front and back frame rails
+// together so cure shrinkage can't bow them apart.
+//
+// Cross-section (looking along Y, bar at centre of void):
+//
+//   overlay top (cosmetic face, on build plate during print)
+//   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//   ┊  frame  ┊          void           ┊  frame  ┊
+//   ┊         ┊     ┌──────────┐        ┊         ┊
+//   ┊         ┊     │   bar    │        ┊         ┊
+//   ━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━
+//   overlay underside (facing up during print)
+//
+// Each bar is overlay_bar_w wide (X) × overlay_bar_h thick (Z) and sits
+// flush against the underside of the slab. They embed overlay_bar_embed mm
+// into the solid frame at each end for a reliable print bond. To remove,
+// flex downward — the thin cross-section snaps at the frame edge.
+//
+// Only the MAIN key field void gets bars (rows 0-4 + ISO Enter). The arrow
+// and display voids are small enough to resist warp on their own.
+
+overlay_bar_w     = 4.0;   // bar width (X direction, mm)
+overlay_bar_h     = 1.5;   // bar height / thickness (Z direction, mm)
+overlay_bar_neck    = 1.0;   // neck height at frame junction (Z, mm). Matches
+                             // tray rib_neck: 1.0 mm nominal keeps worst-case
+                             // at 0.8 mm under ±0.2 mm JLC3DP tolerance.
+overlay_bar_neck_l  = 2.0;   // taper zone length inside the void (mm).
+                             // Matches tray rib_neck_len.
+
+// Main key field bounds in case coords (rows 0-4 + ISO Enter)
+_overlay_void_y0 = p2c_y(min([for (r = [for (i = [0:5]) key_rects[i]]) r[1]]) - key_cap_clearance);
+_overlay_void_y1 = p2c_y(max([for (r = [for (i = [0:5]) key_rects[i]]) r[3]]) + key_cap_clearance);
+_overlay_void_x0 = p2c_x(min([for (r = [for (i = [0:5]) key_rects[i]]) r[0]]) - key_cap_clearance);
+_overlay_void_x1 = p2c_x(max([for (r = [for (i = [0:5]) key_rects[i]]) r[2]]) + key_cap_clearance);
+
+// 5 bars evenly spaced across the void width (~48 mm pitch)
+_overlay_bar_count = 5;
+_overlay_bar_pitch = (_overlay_void_x1 - _overlay_void_x0) / (_overlay_bar_count + 1);
+overlay_bar_cx = [for (i = [1 : _overlay_bar_count])
+                      _overlay_void_x0 + i * _overlay_bar_pitch];
+
+if (PRINT_OVERLAY_SUPPORTS) {
+    assert(overlay_bar_h >= 0.8,
+           str("Overlay bar height ", overlay_bar_h,
+               " mm below JLC3DP 0.8 mm feature minimum"));
+    assert(overlay_bar_w >= 0.8,
+           str("Overlay bar width ", overlay_bar_w,
+               " mm below JLC3DP 0.8 mm feature minimum"));
+}
+
+module overlay_support_bars() {
+    for (cx = overlay_bar_cx)
+        overlay_support_bar(cx);
+}
+
+module overlay_support_bar(cx) {
+    // 0.1 mm overlap into the frame for a clean mesh union
+    _ol = 0.1;
+    y0  = _overlay_void_y0 - _ol;               // front perimeter (tiny overlap)
+    y1  = _overlay_void_y1 + _ol;               // back perimeter  (tiny overlap)
+    ny0 = _overlay_void_y0 + overlay_bar_neck_l; // end of front taper
+    ny1 = _overlay_void_y1 - overlay_bar_neck_l; // start of back taper
+
+    // Front neck: thin at perimeter, tapers to full height over neck_l
+    hull() {
+        translate([cx - overlay_bar_w/2, y0, top_z(y0) - top_t])
+            cube([overlay_bar_w, 0.01, overlay_bar_neck]);
+        translate([cx - overlay_bar_w/2, ny0, top_z(ny0) - top_t])
+            cube([overlay_bar_w, 0.01, overlay_bar_h]);
+    }
+    // Main span at full height
+    hull() {
+        translate([cx - overlay_bar_w/2, ny0, top_z(ny0) - top_t])
+            cube([overlay_bar_w, 0.01, overlay_bar_h]);
+        translate([cx - overlay_bar_w/2, ny1, top_z(ny1) - top_t])
+            cube([overlay_bar_w, 0.01, overlay_bar_h]);
+    }
+    // Back neck: full height tapers to thin at perimeter
+    hull() {
+        translate([cx - overlay_bar_w/2, ny1, top_z(ny1) - top_t])
+            cube([overlay_bar_w, 0.01, overlay_bar_h]);
+        translate([cx - overlay_bar_w/2, y1 - 0.01, top_z(y1) - top_t])
+            cube([overlay_bar_w, 0.01, overlay_bar_neck]);
     }
 }
 


### PR DESCRIPTION
## Summary

- Add 5 flat rectangular tie bars spanning the main key opening void (Y direction, ~48 mm pitch) to prevent frame bowing from SLA cure shrinkage
- Each bar is 4 mm wide × 1.5 mm tall with a 1.0 mm neck taper (2.0 mm ramp) at each frame perimeter connection — matches tray `rib_neck` for JLC3DP spec compliance
- New `PRINT_OVERLAY_SUPPORTS` flag; `build_stl.sh --supports` now enables both tray ribs and overlay bars

## Test plan

- [ ] Render with `PRINT_MODE=true PRINT_OVERLAY_SUPPORTS=true SHOW_OVERLAY=true` — bars visible, flat, flush with slab underside
- [ ] Verify bars do NOT appear in arrow key or display voids
- [ ] Render with `PRINT_OVERLAY_SUPPORTS=false` — no bars, no regressions
- [ ] Run `build_stl.sh --supports --piece overlay --retention magnets` — clean build
- [ ] Confirm neck taper visible at frame perimeter (1.0 mm → 1.5 mm over 2.0 mm)