### PR TITLE
feat: angled print orientation (26° X + 45° Z)

### DIFF
--- a/3d/case/README.md
+++ b/3d/case/README.md
@@ -14,8 +14,9 @@ cd 3d/case
 ```
 
 This produces `mkey_tray.stl` and `mkey_overlay.stl` in the current directory,
-oriented for optimal printing (overlay flipped cosmetic-face-down, tray
-bottom-down). Add supports in your slicer (Lychee, ChiTuBox, etc.).
+oriented for optimal printing (both pieces rotated 26° around the shortest
+axis then 45° around Z — tray open-upright but at an angle). Add supports in
+your slicer (Lychee, ChiTuBox, etc.).
 
 > [!NOTE]
 > **Run `./build_stl.sh` after every parameter or geometry change.** The
@@ -34,15 +35,16 @@ bottom-down). Add supports in your slicer (Lychee, ChiTuBox, etc.).
 ## Print Orientation
 
 The build script sets `PRINT_MODE=true`, which transforms the parts for
-optimal 3D printing:
+optimal 3D printing. Both pieces are rotated **26° around X** (the shortest
+axis / depth direction), then **45° around Z**:
 
-- **Overlay**: The 5-degree wedge tilt is removed so the part lies perfectly flat.
-  The cosmetic face (key openings / display window) is flipped **down** toward
-  the build plate — this gives the best surface finish on both SLA resin and FDM.
+- **Tray**: Sits open-upright but at an angle. The angled orientation
+  reduces layer-line stairstepping on the walls and gives the slicer better
+  support access. Add supports in the slicer as needed.
 
-- **Tray**: Printed bottom-down (the bottom is already flat at Z=0). Add
-  supports in the slicer — place them on outer walls and bottom only, not
-  inside the cavity.
+- **Overlay**: The 6° design tilt is removed first so the part is axis-aligned,
+  then the same 26°/45° print rotation is applied. Add supports in the slicer
+  as needed.
 
 ## Design Parameters (case.scad)
 
@@ -88,32 +90,24 @@ Missing any of these will compromise fit or finish.
 > confirm the compensation in your pre-build screenshots.
 >
 > **TRAY (mkey_tray.stl):**
-> - Orient bottom-face DOWN on the build plate (the flat ~363 × 111 mm face).
->   Walls up, cavity open upward.
-> - Factory supports on the outer side walls and outer bottom are acceptable.
->   **Do not add factory supports inside the cavity.**
+> - The STL is pre-rotated for printing: tilted 26° around the shortest
+>   axis (depth), then 45° around Z. The tray is open-upright but at an
+>   angle. **Do not re-orient — print as supplied.**
+> - Factory supports are acceptable on outer surfaces. **Do not add
+>   factory supports inside the cavity.**
 > - The outer back wall carries a debossed "mKey" logo centred
 >   horizontally, vertically between the bottom chamfer and the wall top
 >   (~43 × 9 mm footprint). Please keep factory support contact points
 >   clear of that debossed region if possible.
 >
 > **OVERLAY (mkey_overlay.stl):**
-> - Orient cosmetic-face DOWN on the build plate (the face with the key
->   openings and display window). The underside, which carries the magnet
->   pockets (or hex nut pockets if using screw retention), faces up.
-> - Place factory supports **only on the outer vertical side walls.** No
->   point supports on the downward-facing cosmetic face (key openings,
->   display window rim, pinstripe groove) and no supports inside the magnet
->   pockets, hex nut pockets, or display pocket on the up-facing underside. A raft under the
->   cosmetic face is acceptable provided the pinstripe groove and key
->   openings drain during post-processing (we IPA-flush these on our end).
-> - **RAFT KEEP-OUT under the display window:** Please keep the raft
->   contact area clear of the ~32 × 38 mm region centred on the display
->   window cutout on the down-facing cosmetic face. The picture-frame
->   around the window is a 1.0 × 1.5 mm cross-grain rib — raft peel
->   forces can fracture it during support removal. An island of bare
->   build-plate under the window (with supports only on the surrounding
->   slab) is preferred.
+> - The STL is pre-rotated for printing: the 6° design tilt is removed,
+>   then the piece is tilted 26° around the shortest axis (depth) and 45°
+>   around Z. **Do not re-orient — print as supplied.**
+> - Place factory supports on outer surfaces only. No supports inside
+>   magnet pockets, hex nut pockets, or the display pocket.
+> - Avoid support contact on the cosmetic face (key openings, display
+>   window rim, pinstripe groove) where possible.
 >
 > Please confirm orientations AND the X-axis scale compensation in the
 > pre-build screenshots before starting the build.

--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -66,8 +66,10 @@ EXPLODE         = 2;       // set >0 to separate overlay from tray (mm)
 
 // ─── Print-mode switches ────────────────────────────────────────────────────
 // When PRINT_MODE is true, the assembly renders print-oriented pieces:
-//   - Overlay is flattened (6° tilt removed) and flipped cosmetic-face-down
-//   - Tray is unchanged in orientation (bottom is already flat)
+//   - Both tray and overlay are tilted 26° around X (shortest axis) then
+//     rotated 45° around Z, so the tray sits open-upright but at an angle.
+//   - The overlay has its 6° design tilt removed first, then the same
+//     26°/45° print rotation is applied.
 // When exporting STLs for manufacturing, set PRINT_MODE=true and render one
 // piece at a time (SHOW_TRAY xor SHOW_OVERLAY).
 PRINT_MODE      = false;   // flip to true (or pass -D) for STL export
@@ -2709,45 +2711,65 @@ module case_overlay_finished() {
 // =============================================================================
 // SECTION 11b: PRINT-MODE MODULES
 // =============================================================================
-// When PRINT_MODE is true, these wrappers re-orient the finished pieces for
-// optimal 3D printing:
-//   - Overlay: flattened (6° tilt removed), flipped cosmetic-face-down
-//   - Tray: orientation unchanged (bottom already flat)
+// When PRINT_MODE is true, both pieces are rotated 26° around X (the shortest
+// axis — depth direction), then 45° around Z.  The tray sits open-upright but
+// at an angle; the overlay has its 6° design tilt removed first so it starts
+// flat before the print rotation is applied.
+//
+// The print_orient() helper centres the piece at the origin, applies the two
+// rotations, then drops the result onto Z=0.
+
+print_tilt  = 26;  // degrees around X (shortest axis)
+print_yaw   = 45;  // degrees around Z
+
+// Helper: centre a bounding box, apply the 26°X + 45°Z print rotation, then
+// project the result down to sit on Z=0.  Caller passes the axis-aligned
+// bounding box [min, max] of the piece before rotation.
+module print_orient(bb_min, bb_max) {
+    cx = (bb_min[0] + bb_max[0]) / 2;
+    cy = (bb_min[1] + bb_max[1]) / 2;
+    cz = (bb_min[2] + bb_max[2]) / 2;
+    hx = (bb_max[0] - bb_min[0]) / 2;
+    hy = (bb_max[1] - bb_min[1]) / 2;
+    hz = (bb_max[2] - bb_min[2]) / 2;
+    // Worst-case Z drop after both rotations — conservatively use the
+    // bounding-sphere radius so the piece is guaranteed above Z=0, then
+    // the slicer or a later translate can seat it exactly.
+    r = norm([hx, hy, hz]);
+    translate([r, r, r])
+    rotate([print_tilt, 0, print_yaw])
+    translate([-cx, -cy, -cz])
+    children();
+}
 
 // ─── Print-oriented overlay ─────────────────────────────────────────────────
-// Undo the 6° wedge tilt so the overlay lies perfectly flat, then flip it
-// upside-down so the cosmetic top surface (key opening / display window)
-// faces the build plate for the best surface finish on SLA and FDM.
-//
-// IMPORTANT: use rotate() not mirror() for the flip — mirror([0,0,1])
-// reverses chirality, which inverts all debossed text and logos.
+// Step 1: remove the 6° design tilt so the overlay is axis-aligned.
+// Step 2: apply the 26°X + 45°Z print rotation via print_orient().
 module case_overlay_print() {
-    // After case_overlay_finished(), the overlay sits in design position:
+    // Flattened overlay bounding box (after tilt removal):
     //   X: -overhang .. overlay_w - overhang
     //   Y: -overhang .. overlay_d - overhang
-    //   Z: overlay_front_h - top_t .. overlay_back_h  (tilted 6°)
-    //
-    // Step 1: rotate -tilt_angle around X to flatten the top/bottom faces.
-    // Step 2: rotate 180° around Y to flip cosmetic face down (preserves
-    //         chirality — text/logos stay correct).  Negates both X and Z.
-    // Step 3: translate so the piece sits on Z=0 with X,Y ≥ 0.
+    //   Z: 0 .. top_t
+    flat_bb_min = [-overhang, -overhang, 0];
+    flat_bb_max = [overlay_w - overhang, overlay_d - overhang, top_t];
 
-    // rotate([0,180,0]) maps (x,y,z) → (-x, y, -z): Z flips (cosmetic face
-    // down) and X flips (compensated by the outer translate).  Y is unchanged
-    // so the overhang shift stays the same as the design-position fix-up.
-    translate([overlay_w - overhang, overhang, 0])
-    rotate([0, 180, 0])
-    translate([0, 0, -top_t])
-    rotate([-tilt_angle, 0, 0])
-    translate([0, 0, -(front_h - top_t)]) {
-        case_overlay_finished();
+    print_orient(flat_bb_min, flat_bb_max) {
+        rotate([-tilt_angle, 0, 0])
+        translate([0, 0, -(front_h - top_t)]) {
+            case_overlay_finished();
+        }
     }
 }
 
 // ─── Print-oriented tray ────────────────────────────────────────────────────
-// The tray bottom is already at Z=0 (flat), so no rotation is needed.
+// The tray is already at Z=0 in design position.  Apply the 26°X + 45°Z
+// print rotation directly.
 module case_tray_print() {
-    case_tray_finished();
+    tray_bb_min = [0, 0, 0];
+    tray_bb_max = [outer_w, outer_d, back_h - top_t];
+
+    print_orient(tray_bb_min, tray_bb_max)
+        case_tray_finished();
 }
 
 // =============================================================================

--- a/3d/case/manufacture/MANUFACTURE_OVERLAY.md
+++ b/3d/case/manufacture/MANUFACTURE_OVERLAY.md
@@ -1,7 +1,7 @@
 # mKey Overlay — Manufacture Notes
 
-SLA standard resin. Orient **cosmetic-face DOWN** (key openings/display window toward build plate). Pockets face up.
+SLA standard resin. The STL is pre-rotated for printing: the 6° design tilt is removed, then the piece is tilted 26° around the shortest axis (depth) and 45° around Z. **Do not re-orient — print as supplied.**
 
 **X-axis scale compensation MANDATORY on this piece.** 363 mm length; uncompensated drift prevents assembly. Confirm in pre-build screenshots.
 
-No supports on cosmetic face or pockets. Raft keep-out under the ~32x38 mm display window — the 1 mm picture-frame rib will fracture under peel forces.
+No supports inside magnet/nut pockets or the display pocket. Avoid support contact on the cosmetic face (key openings, display window rim) where possible. The 1 mm display window picture-frame rib is fragile — keep raft/support contact clear of that region.

--- a/3d/case/manufacture/MANUFACTURE_TRAY.md
+++ b/3d/case/manufacture/MANUFACTURE_TRAY.md
@@ -1,7 +1,7 @@
 # mKey Tray — Manufacture Notes
 
-SLA standard resin. Orient **bottom-face DOWN**, cavity open upward.
+SLA standard resin. The STL is pre-rotated for printing: tilted 26° around the shortest axis (depth), then 45° around Z. The tray sits open-upright but at an angle. **Do not re-orient — print as supplied.**
 
 **X-axis scale compensation MANDATORY on this piece.** 363 mm length; uncompensated drift prevents assembly. Confirm in pre-build screenshots.
 
-Outer walls/bottom supports OK; avoid placing supports inside the cavity or on the debossed "mKey" logo on the outer back wall.
+Outer-surface supports OK; avoid placing supports inside the cavity or on the debossed "mKey" logo on the outer back wall.


### PR DESCRIPTION
## Summary
- Print both tray and overlay at an angle: 26° around X (shortest axis), then 45° around Z — tray open-upright but tilted
- Added `print_orient()` helper module with `print_tilt`/`print_yaw` parameters for easy tuning
- Updated README print orientation section, JLC3DP submission notes, and both manufacture notes to reflect the new orientation ("pre-rotated, print as supplied")

## Test plan
- [ ] Preview in OpenSCAD with `PRINT_MODE=true`, `SHOW_TRAY=true` — tray should be open-upright at an angle, fully in positive axis space
- [ ] Preview with `SHOW_OVERLAY=true` — overlay should have same rotation, no design tilt
- [ ] Run `./build_stl.sh` and verify STL exports cleanly
- [ ] Verify STL orientation in slicer matches expectations