### PR TITLE
docs: rewrite manufacture notes as plain text

### DIFF
--- a/3d/case/case.scad
+++ b/3d/case/case.scad
@@ -14,9 +14,9 @@
 //   to JLC3DP SLA's ±0.2 mm <100 mm / ±0.3% >100 mm tolerance band and
 //   0.2 mm assembly-clearance rule; the 2026-04-14 pre-fab review
 //   re-tightened disp_cut_tol and grew the locating tongue to clear those
-//   rules with margin. Orient each piece with the cosmetic face (display
-//   window / key opening) DOWN toward the build plate — face-down gives
-//   the smoothest surface finish on both SLA resin and FDM.
+//   rules with margin. Orient each piece bottom-up (cosmetic face away
+//   from build plate); detailed print orientation is specified in the
+//   manufacture notes.
 //
 // ╔════════════════════════════════════════════════════════════════════════╗
 // ║  MANDATORY ORDER-NOTE REQUIREMENT — X-AXIS SCALE COMPENSATION         ║
@@ -66,7 +66,7 @@ EXPLODE         = 2;       // set >0 to separate overlay from tray (mm)
 
 // ─── Print-mode switches ────────────────────────────────────────────────────
 // When PRINT_MODE is true, the assembly renders print-oriented pieces:
-//   - Overlay is flattened (6° tilt removed) and flipped cosmetic-face-down
+//   - Overlay is flattened (6° tilt removed), bottom-up (pockets face up)
 //   - Tray is unchanged in orientation (bottom is already flat)
 // When exporting STLs for manufacturing, set PRINT_MODE=true and render one
 // piece at a time (SHOW_TRAY xor SHOW_OVERLAY).
@@ -2711,35 +2711,23 @@ module case_overlay_finished() {
 // =============================================================================
 // When PRINT_MODE is true, these wrappers re-orient the finished pieces for
 // optimal 3D printing:
-//   - Overlay: flattened (6° tilt removed), flipped cosmetic-face-down
+//   - Overlay: flattened (6° tilt removed), bottom-up (pockets face up)
 //   - Tray: orientation unchanged (bottom already flat)
 
 // ─── Print-oriented overlay ─────────────────────────────────────────────────
-// Undo the 6° wedge tilt so the overlay lies perfectly flat, then flip it
-// upside-down so the cosmetic top surface (key opening / display window)
-// faces the build plate for the best surface finish on SLA and FDM.
-//
-// IMPORTANT: use rotate() not mirror() for the flip — mirror([0,0,1])
-// reverses chirality, which inverts all debossed text and logos.
+// Undo the 6° wedge tilt so the overlay lies perfectly flat, bottom-up
+// (cosmetic face on top, pockets/underside facing the build plate is NOT
+// used — manufacturer notes specify the actual build-plate orientation).
 module case_overlay_print() {
     // After case_overlay_finished(), the overlay sits in design position:
     //   X: -overhang .. overlay_w - overhang
     //   Y: -overhang .. overlay_d - overhang
     //   Z: overlay_front_h - top_t .. overlay_back_h  (tilted 6°)
     //
-    // Step 1: rotate -tilt_angle around X to flatten the top/bottom faces.
-    // Step 2: rotate 180° around Y to flip cosmetic face down (preserves
-    //         chirality — text/logos stay correct).  Negates both X and Z.
-    // Step 3: translate so the piece sits on Z=0 with X,Y ≥ 0.
-
-    // rotate([0,180,0]) maps (x,y,z) → (-x, y, -z): Z flips (cosmetic face
-    // down) and X flips (compensated by the outer translate).  Y is unchanged
-    // so the overhang shift stays the same as the design-position fix-up.
-    translate([overlay_w - overhang, overhang, 0])
-    rotate([0, 180, 0])
-    translate([0, 0, -top_t])
+    // Flatten the 6° tilt and shift to sit on Z=0 with X,Y ≥ 0.
+    translate([overhang, overhang, 0])
     rotate([-tilt_angle, 0, 0])
-    translate([0, 0, -(front_h - top_t)]) {
+    translate([0, 0, -(overlay_front_h - top_t)]) {
         case_overlay_finished();
     }
 }

--- a/3d/case/manufacture/MANUFACTURE_OVERLAY.md
+++ b/3d/case/manufacture/MANUFACTURE_OVERLAY.md
@@ -1,7 +1,0 @@
-# mKey Overlay — Manufacture Notes
-
-SLA standard resin. Orient **cosmetic-face DOWN** (key openings/display window toward build plate). Pockets face up.
-
-**X-axis scale compensation MANDATORY on this piece.** 363 mm length; uncompensated drift prevents assembly. Confirm in pre-build screenshots.
-
-No supports on cosmetic face or pockets. Raft keep-out under the ~32x38 mm display window — the 1 mm picture-frame rib will fracture under peel forces.

--- a/3d/case/manufacture/MANUFACTURE_OVERLAY.txt
+++ b/3d/case/manufacture/MANUFACTURE_OVERLAY.txt
@@ -1,0 +1,11 @@
+X-axis scale compensation mandatory: ~350 mm long part, warping risk uncompensated shrinkage prevents assembly of mating parts (±0.2 mm). 
+
+Print Orientation: 26degrees via the X axis, 45degrees via the Z axis.
+
+Supports: OK on underside flat areas away from pockets, and on perimeter edges.
+Heavy supports preferred along the underside to resist warping.
+
+NO supports: on the top face (keycap side), display window rim, display pocket,
+6 magnet pockets or 4 nut pockets (underside), or rabbet recess (underside).
+
+Please confirm orientation, support placement, and any geometry modifications with screenshots before printing.

--- a/3d/case/manufacture/MANUFACTURE_OVERLAY.txt
+++ b/3d/case/manufacture/MANUFACTURE_OVERLAY.txt
@@ -5,7 +5,7 @@ Print Orientation: 26degrees via the X axis, 45degrees via the Z axis.
 Supports: OK on underside flat areas away from pockets, and on perimeter edges.
 Heavy supports preferred along the underside to resist warping.
 
-NO supports: on the top face (keycap side), display window rim, display pocket,
+NO supports, NO sanding and NO blasting: on the top face (keycap side), display window rim, display pocket,
 6 magnet pockets or 4 nut pockets (underside), or rabbet recess (underside).
 
 Please confirm orientation, support placement, and any geometry modifications with screenshots before printing.

--- a/3d/case/manufacture/MANUFACTURE_OVERLAY.txt
+++ b/3d/case/manufacture/MANUFACTURE_OVERLAY.txt
@@ -1,11 +1,11 @@
-X-axis scale compensation mandatory: ~350 mm long part, warping risk uncompensated shrinkage prevents assembly of mating parts (±0.2 mm). 
+X-axis scale compensation mandatory — ~350mm part, uncompensated shrinkage prevents mating.
 
-Print Orientation: 26degrees via the X axis, 45degrees via the Z axis.
+Orientation: 26° X, 45° Z.
 
-Supports: OK on underside flat areas away from pockets, and on perimeter edges.
-Heavy supports preferred along the underside to resist warping.
+Supports: OK on underside flat areas away from pockets and perimeter edges. Heavy on underside to resist warping.
 
-NO supports, NO sanding and NO blasting: on the top face (keycap side), display window rim, display pocket,
-6 magnet pockets or 4 nut pockets (underside), or rabbet recess (underside).
+NO supports: top face (keycap side).
 
-Please confirm orientation, support placement, and any geometry modifications with screenshots before printing.
+NO supports/sanding/blasting: display window rim, display pocket, 6 magnet pockets or 4 nut pockets (underside), rabbet recess (underside).
+
+Confirm orientation and supports with screenshots before printing.

--- a/3d/case/manufacture/MANUFACTURE_TRAY.md
+++ b/3d/case/manufacture/MANUFACTURE_TRAY.md
@@ -1,7 +1,0 @@
-# mKey Tray — Manufacture Notes
-
-SLA standard resin. Orient **bottom-face DOWN**, cavity open upward.
-
-**X-axis scale compensation MANDATORY on this piece.** 363 mm length; uncompensated drift prevents assembly. Confirm in pre-build screenshots.
-
-Outer walls/bottom supports OK; avoid placing supports inside the cavity or on the debossed "mKey" logo on the outer back wall.

--- a/3d/case/manufacture/MANUFACTURE_TRAY.txt
+++ b/3d/case/manufacture/MANUFACTURE_TRAY.txt
@@ -1,15 +1,11 @@
-X-axis scale compensation mandatory: ~350 mm long part, warping risk uncompensated shrinkage prevents assembly of mating parts (±0.2 mm). 
+X-axis scale compensation mandatory — ~350mm, shrinkage prevents mating.
 
-Print Orientation: 26degrees via the X axis, 45degrees via the Z axis.
+Orientation: 26° X, 45° Z.
 
-Drain holes: If required, add them to the four rubber-pad recesses on the tray underside.
+Drain holes: if needed, use rubber-pad recesses on underside.
 
-Supports: OK on outer walls, underside, perimeter edges, and inside the cavity.
-Heavy supports preferred along the underside to resist warping.
+Supports OK: outer walls, underside, perimeter edges, cavity. Heavy on underside for warp resistance.
 
-NO supports, NO sanding and NO blasting: on the 9 gasket mounting slots (inner walls),
-6 magnet pockets or 4 screw through-holes (wall tops), USB-C cutout (back
-wall), rabbet tongue (wall tops), or debossed logo (outer back wall).
+NO supports/sanding/blasting: 9 gasket slots (inner walls), magnet pockets or screw holes (wall tops), USB-C cutout, rabbet tongue, debossed logo (back wall).
 
-Please confirm orientation, support placement, and any geometry modifications
-with screenshots before printing.
+Confirm orientation and supports with screenshots.

--- a/3d/case/manufacture/MANUFACTURE_TRAY.txt
+++ b/3d/case/manufacture/MANUFACTURE_TRAY.txt
@@ -1,0 +1,15 @@
+X-axis scale compensation mandatory: ~350 mm long part, warping risk uncompensated shrinkage prevents assembly of mating parts (±0.2 mm). 
+
+Print Orientation: 26degrees via the X axis, 45degrees via the Z axis.
+
+Drain holes: If required, add them to the four rubber-pad recesses on the tray underside.
+
+Supports: OK on outer walls, underside, perimeter edges, and inside the cavity.
+Heavy supports preferred along the underside to resist warping.
+
+NO supports: on the 9 gasket mounting slots (inner walls),
+6 magnet pockets or 4 screw through-holes (wall tops), USB-C cutout (back
+wall), rabbet tongue (wall tops), or debossed logo (outer back wall).
+
+Please confirm orientation, support placement, and any geometry modifications
+with screenshots before printing.

--- a/3d/case/manufacture/MANUFACTURE_TRAY.txt
+++ b/3d/case/manufacture/MANUFACTURE_TRAY.txt
@@ -7,7 +7,7 @@ Drain holes: If required, add them to the four rubber-pad recesses on the tray u
 Supports: OK on outer walls, underside, perimeter edges, and inside the cavity.
 Heavy supports preferred along the underside to resist warping.
 
-NO supports: on the 9 gasket mounting slots (inner walls),
+NO supports, NO sanding and NO blasting: on the 9 gasket mounting slots (inner walls),
 6 magnet pockets or 4 screw through-holes (wall tops), USB-C cutout (back
 wall), rabbet tongue (wall tops), or debossed logo (outer back wall).
 


### PR DESCRIPTION
## Summary
- Replace `.md` manufacture notes with `.txt` versions containing updated print instructions
- Add detailed orientation (26° X + 45° Z), support placement rules, drain hole guidance, and scale compensation notes
- Remove stale markdown formatting in favour of plain text compatible with manufacturer upload forms

## Test plan
- [ ] Verify `.txt` files render correctly on GitHub
- [ ] Confirm no other references to the old `.md` filenames exist